### PR TITLE
feat(response): save body to file with smart filename

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,7 +1,8 @@
-import { app, BrowserWindow, ipcMain, session, shell } from 'electron';
+import { app, BrowserWindow, dialog, ipcMain, session, shell } from 'electron';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { randomUUID } from 'node:crypto';
+import { writeFile } from 'node:fs/promises';
 import {
   UndiciExecutor,
   ExecutorError,
@@ -284,6 +285,31 @@ app.whenReady().then(() => {
   ipcMain.handle('request:cancel', (_e, requestId: string): void => {
     requestRuns.get(requestId)?.abort();
   });
+
+  ipcMain.handle(
+    'response:save',
+    async (
+      _e,
+      bodyBase64: string,
+      suggestedName: string,
+    ): Promise<{ ok: boolean; path?: string; canceled?: boolean }> => {
+      const focused = BrowserWindow.getFocusedWindow();
+      const result = focused
+        ? await dialog.showSaveDialog(focused, { defaultPath: suggestedName })
+        : await dialog.showSaveDialog({ defaultPath: suggestedName });
+      if (result.canceled || !result.filePath) {
+        return { ok: false, canceled: true };
+      }
+      try {
+        const buf = Buffer.from(bodyBase64, 'base64');
+        await writeFile(result.filePath, buf);
+        return { ok: true, path: result.filePath };
+      } catch (err) {
+        console.error('[scrapeman] response save failed:', err);
+        return { ok: false };
+      }
+    },
+  );
 
   ipcMain.handle(
     'history:list',

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -31,6 +31,12 @@ const api: ScrapemanBridge = {
     ) as Promise<ExecuteResult>,
   cancelRequest: (requestId: string) =>
     ipcRenderer.invoke('request:cancel', requestId) as Promise<void>,
+  saveResponse: (bodyBase64: string, suggestedName: string) =>
+    ipcRenderer.invoke(
+      'response:save',
+      bodyBase64,
+      suggestedName,
+    ) as Promise<{ ok: boolean; path?: string; canceled?: boolean }>,
   importCurl: (input: string) =>
     ipcRenderer.invoke('curl:import', input) as Promise<ImportCurlResult>,
   generateCode: (input: CodegenInput) =>

--- a/apps/desktop/src/renderer/src/components/ResponseViewer.tsx
+++ b/apps/desktop/src/renderer/src/components/ResponseViewer.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import type { ExecutedResponse } from '@scrapeman/shared-types';
+import { bridge } from '../bridge.js';
 import { useAppStore } from '../store.js';
 import { JsonTree } from './JsonTree.js';
 
@@ -38,6 +39,10 @@ export function ResponseViewer(): JSX.Element {
   const execution = useAppStore((s) => {
     const active = s.tabs.find((t) => t.id === s.activeTabId);
     return active?.execution ?? null;
+  });
+  const requestUrl = useAppStore((s) => {
+    const active = s.tabs.find((t) => t.id === s.activeTabId);
+    return active?.builder.url ?? '';
   });
   const [tab, setTab] = useState<Tab>('body');
 
@@ -101,8 +106,18 @@ export function ResponseViewer(): JSX.Element {
         )}
         <Metric label="Size" value={formatBytes(response.sizeBytes)} />
         <Metric label="Protocol" value={response.httpVersion} />
+        <button
+          onClick={() => {
+            const name = deriveFilename(response, requestUrl);
+            void bridge.saveResponse(response.bodyBase64, name);
+          }}
+          className="ml-auto rounded px-2 py-1 text-[11px] font-medium text-ink-2 hover:bg-bg-hover hover:text-ink-1"
+          title="Save response body to file"
+        >
+          Save
+        </button>
         {response.bodyTruncated && (
-          <span className="ml-auto rounded bg-method-post/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-method-post">
+          <span className="rounded bg-method-post/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-method-post">
             truncated
           </span>
         )}
@@ -729,6 +744,79 @@ function TabButton({
       {children}
     </button>
   );
+}
+
+const MIME_EXT: Record<string, string> = {
+  'application/json': '.json',
+  'text/html': '.html',
+  'application/xml': '.xml',
+  'text/xml': '.xml',
+  'application/pdf': '.pdf',
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'text/plain': '.txt',
+  'application/octet-stream': '.bin',
+};
+
+function extForContentType(contentType: string | undefined): string {
+  if (!contentType) return '.bin';
+  const mime = contentType.split(';')[0]!.trim().toLowerCase();
+  if (MIME_EXT[mime]) return MIME_EXT[mime]!;
+  if (mime.includes('json')) return '.json';
+  if (mime.includes('html')) return '.html';
+  if (mime.includes('xml')) return '.xml';
+  if (mime === 'text/plain') return '.txt';
+  return '.bin';
+}
+
+function parseContentDispositionFilename(
+  headers: Array<[string, string]>,
+): string | null {
+  const header = headers.find(([n]) => n.toLowerCase() === 'content-disposition');
+  if (!header) return null;
+  const value = header[1];
+  // RFC 5987 filename*=UTF-8''encoded — prefer over filename=
+  const starMatch = /filename\*\s*=\s*([^;]+)/i.exec(value);
+  if (starMatch) {
+    const raw = starMatch[1]!.trim();
+    const parts = raw.split("''");
+    const encoded = parts.length === 2 ? parts[1]! : raw;
+    try {
+      return decodeURIComponent(encoded);
+    } catch {
+      /* fall through */
+    }
+  }
+  const match = /filename\s*=\s*("([^"]+)"|([^;]+))/i.exec(value);
+  if (match) {
+    return (match[2] ?? match[3] ?? '').trim() || null;
+  }
+  return null;
+}
+
+function deriveFilename(
+  response: ExecutedResponse,
+  requestUrl: string,
+): string {
+  const fromCd = parseContentDispositionFilename(response.headers);
+  if (fromCd) return fromCd;
+
+  let base = 'response';
+  try {
+    const u = new URL(requestUrl);
+    const last = u.pathname.split('/').filter(Boolean).pop();
+    if (last) base = last;
+  } catch {
+    const noQuery = requestUrl.split('?')[0] ?? '';
+    const last = noQuery.split('/').filter(Boolean).pop();
+    if (last) base = last;
+  }
+
+  const hasExt = /\.[A-Za-z0-9]{1,8}$/.test(base);
+  if (hasExt) return base;
+  return base + extForContentType(response.contentType);
 }
 
 function formatBytes(bytes: number): string {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -315,6 +315,10 @@ export interface ScrapemanBridge {
     requestId: string,
   ) => Promise<ExecuteResult>;
   cancelRequest: (requestId: string) => Promise<void>;
+  saveResponse: (
+    bodyBase64: string,
+    suggestedName: string,
+  ) => Promise<{ ok: boolean; path?: string; canceled?: boolean }>;
   importCurl: (input: string) => Promise<ImportCurlResult>;
   generateCode: (input: CodegenInput) => Promise<string>;
 


### PR DESCRIPTION
Kapatır #7.

Response panel header'ına **Save** butonu eklendi: sadece `success` durumunda görünür, native save dialog açar, body byte'ları aynen diske yazar (base64 -> Buffer, re-encode yok).

## Akıllı dosya adı
1. `Content-Disposition: attachment; filename="..."` (RFC 5987 `filename*` destekli)
2. URL'in son path segment'i (query strip)
3. `response` fallback

Uzantı Content-Type'tan türer: `json` -> `.json`, `html` -> `.html`, `xml` -> `.xml`, `pdf` -> `.pdf`, `png` -> `.png`, `jpeg` -> `.jpg`, `gif` -> `.gif`, `webp` -> `.webp`, `text/plain` -> `.txt`, `octet-stream` / bilinmeyen -> `.bin`. Dosya adında zaten uzantı varsa korunur.

## Değişen yerler
- `apps/desktop/src/main/index.ts` — `response:save` IPC handler (`dialog.showSaveDialog` + `fs.writeFile`)
- `apps/desktop/src/preload/index.ts` — `saveResponse` bridge
- `packages/shared-types/src/index.ts` — `ScrapemanBridge.saveResponse` tipi
- `apps/desktop/src/renderer/src/components/ResponseViewer.tsx` — Save button + `deriveFilename` helper

## Test
- `pnpm -r typecheck` OK
- `pnpm -r test` OK (125/125)
- `pnpm --filter=@scrapeman/desktop build` OK