### PR TITLE
feat(ui): loading animation while request in flight

### DIFF
--- a/apps/desktop/src/renderer/src/components/RequestBuilder.tsx
+++ b/apps/desktop/src/renderer/src/components/RequestBuilder.tsx
@@ -155,9 +155,10 @@ export function RequestBuilder(): JSX.Element {
         {sending ? (
           <button
             onClick={cancelSend}
-            className="btn-secondary min-w-[86px]"
+            className="btn-secondary min-w-[86px] gap-1.5"
             title="Cancel request"
           >
+            <span className="spinner" aria-hidden="true" />
             Cancel
           </button>
         ) : (
@@ -170,6 +171,8 @@ export function RequestBuilder(): JSX.Element {
           </button>
         )}
       </div>
+
+      {sending && <div className="progress-indeterminate" aria-hidden="true" />}
 
       <div className="flex h-9 items-center border-b border-line px-4">
         <TabButton active={tab === 'params'} onClick={() => setTab('params')}>

--- a/apps/desktop/src/renderer/src/components/ResponseViewer.tsx
+++ b/apps/desktop/src/renderer/src/components/ResponseViewer.tsx
@@ -59,7 +59,15 @@ export function ResponseViewer(): JSX.Element {
 
   if (execution.status === 'sending') {
     return (
-      <EmptyState icon="↻" title="Sending…" description="Awaiting response." />
+      <div className="flex h-full flex-col items-center justify-center gap-3">
+        <div className="flex h-11 w-11 items-center justify-center rounded-full bg-bg-muted text-accent">
+          <span className="spinner" aria-hidden="true" />
+        </div>
+        <div className="text-center">
+          <div className="text-sm font-semibold text-ink-1">Sending…</div>
+          <div className="mt-1 text-xs text-ink-3">Awaiting response.</div>
+        </div>
+      </div>
     );
   }
 

--- a/apps/desktop/src/renderer/src/components/TabBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TabBar.tsx
@@ -54,6 +54,7 @@ function TabItem({
   onClose: () => void;
 }): JSX.Element {
   const color = METHOD_COLOR[tab.method] ?? 'text-method-custom';
+  const sending = tab.execution.status === 'sending';
 
   return (
     <div
@@ -77,6 +78,12 @@ function TabItem({
         {tab.method.slice(0, 6)}
       </span>
       <span className="flex-1 truncate">{tab.name}</span>
+      {sending && (
+        <span
+          title="Request in flight"
+          className="pulse-dot h-1.5 w-1.5 rounded-sm bg-accent"
+        />
+      )}
       {tab.dirty ? (
         <span className="h-1.5 w-1.5 rounded-full bg-accent" />
       ) : (

--- a/apps/desktop/src/renderer/src/styles.css
+++ b/apps/desktop/src/renderer/src/styles.css
@@ -152,6 +152,69 @@ html.dark {
   }
 }
 
+@keyframes progress-indeterminate {
+  0% {
+    left: -40%;
+    width: 40%;
+  }
+  50% {
+    left: 20%;
+    width: 60%;
+  }
+  100% {
+    left: 100%;
+    width: 40%;
+  }
+}
+
+.progress-indeterminate {
+  position: relative;
+  height: 2px;
+  overflow: hidden;
+  background-color: rgb(var(--bg-muted));
+}
+.progress-indeterminate::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  height: 100%;
+  background-color: theme(colors.accent.DEFAULT);
+  animation: progress-indeterminate 1.1s ease-in-out infinite;
+}
+
+@keyframes spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.spinner {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  border-radius: 9999px;
+  border: 1.5px solid currentColor;
+  border-top-color: transparent;
+  animation: spinner-rotate 0.7s linear infinite;
+  vertical-align: -2px;
+}
+
+@keyframes pulse-dot {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.9);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
+}
+
+.pulse-dot {
+  animation: pulse-dot 0.9s ease-in-out infinite;
+}
+
 ::-webkit-scrollbar {
   width: 10px;
   height: 10px;


### PR DESCRIPTION
Kapatır #3.

- URL satırının altına, istek uçuştayken görünen 2px indeterminate accent progress bar eklendi.
- Send butonu Cancel'a dönüştüğünde yanında küçük bir CSS spinner beliriyor, böylece hareket görünür oluyor.
- Tab başlığında, in-flight tab'ler için dirty dot'tan farklı şekilde pulse eden küçük bir indicator çizildi (dirty dot olduğu gibi kalıyor).
- ResponseViewer'daki statik "Sending…" metni aynı spinner + label ile değiştirildi.
- Saf CSS keyframes, yeni dependency yok; Tailwind token'ları ve mevcut CSS değişkenleri kullanıldı (dark mode otomatik).