### PR TITLE
feat(settings): storage panel with history path, stats, clear

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, ipcMain, session, shell } from 'electron';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import { promises as fsp } from 'node:fs';
 import { randomUUID } from 'node:crypto';
 import {
   UndiciExecutor,
@@ -298,6 +299,46 @@ app.whenReady().then(() => {
   ipcMain.handle('history:clear', (_e, workspacePath: string) =>
     historyStore?.clear(workspacePath),
   );
+  ipcMain.handle(
+    'history:stats',
+    async (
+      _e,
+      workspacePath: string,
+    ): Promise<{ count: number; diskBytes: number; path: string }> => {
+      if (!historyStore) return { count: 0, diskBytes: 0, path: '' };
+      const path = historyStore.getFilePath(workspacePath);
+      const entries = await historyStore.list(workspacePath, {});
+      let diskBytes = 0;
+      try {
+        const stat = await fsp.stat(path);
+        diskBytes = stat.size;
+      } catch {
+        /* file may not exist yet */
+      }
+      return { count: entries.length, diskBytes, path };
+    },
+  );
+  ipcMain.handle('history:clearAll', async (): Promise<void> => {
+    if (!historyStore) return;
+    const root = historyStore.getRootPath();
+    let files: string[] = [];
+    try {
+      files = await fsp.readdir(root);
+    } catch {
+      return;
+    }
+    await Promise.all(
+      files
+        .filter((f) => f.endsWith('.jsonl'))
+        .map((f) =>
+          fsp.writeFile(join(root, f), '', 'utf8').catch(() => undefined),
+        ),
+    );
+    historyStore.invalidateCache();
+  });
+  ipcMain.handle('app:openInShell', (_e, path: string): void => {
+    shell.showItemInFolder(path);
+  });
 
   ipcMain.handle(
     'cookies:list',

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -115,6 +115,16 @@ const api: ScrapemanBridge = {
     ipcRenderer.invoke('history:delete', workspacePath, id) as Promise<void>,
   historyClear: (workspacePath: string) =>
     ipcRenderer.invoke('history:clear', workspacePath) as Promise<void>,
+  historyStats: (workspacePath: string) =>
+    ipcRenderer.invoke('history:stats', workspacePath) as Promise<{
+      count: number;
+      diskBytes: number;
+      path: string;
+    }>,
+  historyClearAll: () =>
+    ipcRenderer.invoke('history:clearAll') as Promise<void>,
+  openInShell: (path: string) =>
+    ipcRenderer.invoke('app:openInShell', path) as Promise<void>,
 
   cookieList: (workspacePath: string) =>
     ipcRenderer.invoke('cookies:list', workspacePath) as Promise<CookieEntry[]>,

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -5,6 +5,7 @@ import { ResponseViewer } from './components/ResponseViewer.js';
 import { TabBar } from './components/TabBar.js';
 import { EnvironmentMenu } from './components/EnvironmentMenu.js';
 import { CookiesPanel } from './components/CookiesPanel.js';
+import { SettingsDialog } from './components/SettingsDialog.js';
 import { SplitPane, type SplitOrientation } from './components/SplitPane.js';
 import { useAppStore } from './store.js';
 import { bridge } from './bridge.js';
@@ -71,6 +72,7 @@ export function App(): JSX.Element {
   const isMac = platform === 'darwin';
 
   const [cookiesOpen, setCookiesOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const { theme, toggle: toggleTheme } = useTheme();
 
   const [splitOrientation, setSplitOrientation] = useState<SplitOrientation>(
@@ -132,9 +134,17 @@ export function App(): JSX.Element {
             </button>
           )}
           {workspace && <EnvironmentMenu />}
+          <button
+            onClick={() => setSettingsOpen(true)}
+            title="Settings"
+            className="app-no-drag flex h-7 w-7 items-center justify-center rounded-md border border-line bg-bg-canvas text-ink-3 hover:bg-bg-hover hover:text-ink-1"
+          >
+            ⚙
+          </button>
         </div>
       </header>
       <CookiesPanel open={cookiesOpen} onClose={() => setCookiesOpen(false)} />
+      <SettingsDialog open={settingsOpen} onClose={() => setSettingsOpen(false)} />
       <div className="flex-1 overflow-hidden">
         <SplitPane
           orientation="horizontal"

--- a/apps/desktop/src/renderer/src/components/SettingsDialog.tsx
+++ b/apps/desktop/src/renderer/src/components/SettingsDialog.tsx
@@ -1,0 +1,217 @@
+import * as RadixDialog from '@radix-ui/react-dialog';
+import { useCallback, useEffect, useState } from 'react';
+import { bridge } from '../bridge.js';
+import { useAppStore } from '../store.js';
+import { usePlatform } from '../hooks/usePlatform.js';
+import { ConfirmDialog } from '../ui/Dialog.js';
+
+interface HistoryStats {
+  count: number;
+  diskBytes: number;
+  path: string;
+}
+
+export function SettingsDialog({
+  open,
+  onClose,
+}: {
+  open: boolean;
+  onClose: () => void;
+}): JSX.Element {
+  const workspace = useAppStore((s) => s.workspace);
+  const loadHistory = useAppStore((s) => s.loadHistory);
+  const platform = usePlatform();
+  const revealLabel = platform === 'darwin' ? 'Reveal in Finder' : 'Show in Explorer';
+
+  const [stats, setStats] = useState<HistoryStats | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const [confirmClearOne, setConfirmClearOne] = useState(false);
+  const [confirmClearAll, setConfirmClearAll] = useState(false);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    if (!workspace) {
+      setStats(null);
+      return;
+    }
+    setLoading(true);
+    try {
+      const next = await bridge.historyStats(workspace.path);
+      setStats(next);
+    } finally {
+      setLoading(false);
+    }
+  }, [workspace]);
+
+  useEffect(() => {
+    if (open) void refresh();
+  }, [open, refresh]);
+
+  const copyPath = async (): Promise<void> => {
+    if (!stats?.path) return;
+    try {
+      await navigator.clipboard.writeText(stats.path);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* ignore */
+    }
+  };
+
+  const clearCurrent = async (): Promise<void> => {
+    if (!workspace) return;
+    await bridge.historyClear(workspace.path);
+    await loadHistory();
+    await refresh();
+  };
+
+  const clearAll = async (): Promise<void> => {
+    await bridge.historyClearAll();
+    await loadHistory();
+    await refresh();
+  };
+
+  return (
+    <>
+      <RadixDialog.Root open={open} onOpenChange={(next) => !next && onClose()}>
+        <RadixDialog.Portal>
+          <RadixDialog.Overlay className="fixed inset-0 z-50 bg-ink-1/20 backdrop-blur-[2px] animate-fade-in" />
+          <RadixDialog.Content className="fixed left-1/2 top-1/2 z-50 w-[560px] -translate-x-1/2 -translate-y-1/2 rounded-lg border border-line bg-bg-canvas p-5 shadow-popover animate-slide-down-fade">
+            <RadixDialog.Title className="text-sm font-semibold text-ink-1">
+              Settings
+            </RadixDialog.Title>
+            <RadixDialog.Description className="mt-1 text-xs text-ink-3">
+              Manage where Scrapeman keeps request history on disk.
+            </RadixDialog.Description>
+
+            <section className="mt-5">
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-ink-3">
+                Storage
+              </div>
+
+              {!workspace && (
+                <div className="mt-3 rounded-md border border-line bg-bg-subtle px-3 py-2 text-xs text-ink-3">
+                  Open a workspace to see storage details.
+                </div>
+              )}
+
+              {workspace && (
+                <div className="mt-3 space-y-3">
+                  <div>
+                    <div className="text-[11px] text-ink-3">History file</div>
+                    <div className="mt-1 flex items-center gap-2">
+                      <code className="flex-1 truncate rounded-md border border-line bg-bg-subtle px-2 py-1.5 font-mono text-[11px] text-ink-2">
+                        {stats?.path ?? '…'}
+                      </code>
+                      <button
+                        type="button"
+                        className="btn-secondary"
+                        onClick={() => void copyPath()}
+                        disabled={!stats?.path}
+                        title="Copy path"
+                      >
+                        {copied ? 'Copied' : 'Copy'}
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-secondary"
+                        onClick={() => stats?.path && void bridge.openInShell(stats.path)}
+                        disabled={!stats?.path}
+                      >
+                        {revealLabel}
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-3">
+                    <Metric
+                      label="Entries"
+                      value={loading && !stats ? '…' : String(stats?.count ?? 0)}
+                    />
+                    <Metric
+                      label="Disk usage"
+                      value={
+                        loading && !stats
+                          ? '…'
+                          : formatBytes(stats?.diskBytes ?? 0)
+                      }
+                    />
+                  </div>
+
+                  <div className="flex items-center justify-end">
+                    <button
+                      type="button"
+                      onClick={() => setConfirmClearOne(true)}
+                      className="inline-flex h-8 items-center justify-center rounded-md bg-method-delete px-3.5 text-xs font-semibold text-white hover:bg-[#B6383D] active:bg-[#9D3034]"
+                      disabled={!stats || stats.count === 0}
+                    >
+                      Clear this workspace
+                    </button>
+                  </div>
+                </div>
+              )}
+            </section>
+
+            <section className="mt-6 border-t border-line pt-5">
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-ink-3">
+                All workspaces
+              </div>
+              <div className="mt-3 flex items-center justify-between gap-3">
+                <div className="text-xs text-ink-3">
+                  Wipe history files for every workspace stored on this machine.
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setConfirmClearAll(true)}
+                  className="inline-flex h-8 items-center justify-center rounded-md bg-method-delete px-3.5 text-xs font-semibold text-white hover:bg-[#B6383D] active:bg-[#9D3034]"
+                >
+                  Clear all history
+                </button>
+              </div>
+            </section>
+
+            <div className="mt-6 flex items-center justify-end">
+              <button type="button" className="btn-secondary" onClick={onClose}>
+                Close
+              </button>
+            </div>
+          </RadixDialog.Content>
+        </RadixDialog.Portal>
+      </RadixDialog.Root>
+
+      <ConfirmDialog
+        open={confirmClearOne}
+        title="Clear this workspace history?"
+        description="All recorded requests for the current workspace will be removed. This cannot be undone."
+        confirmLabel="Clear"
+        destructive
+        onConfirm={() => void clearCurrent()}
+        onClose={() => setConfirmClearOne(false)}
+      />
+      <ConfirmDialog
+        open={confirmClearAll}
+        title="Clear history for all workspaces?"
+        description="Every workspace history file on this machine will be emptied. This cannot be undone."
+        confirmLabel="Clear all"
+        destructive
+        onConfirm={() => void clearAll()}
+        onClose={() => setConfirmClearAll(false)}
+      />
+    </>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }): JSX.Element {
+  return (
+    <div className="rounded-md border border-line bg-bg-subtle px-3 py-2">
+      <div className="text-[10px] uppercase tracking-wide text-ink-3">{label}</div>
+      <div className="mt-0.5 font-mono text-sm text-ink-1">{value}</div>
+    </div>
+  );
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/packages/http-core/src/history/store.ts
+++ b/packages/http-core/src/history/store.ts
@@ -168,6 +168,22 @@ export class HistoryStore {
     const hash = createHash('sha1').update(workspacePath).digest('hex').slice(0, 16);
     return join(this.rootDir, 'history', `${hash}.jsonl`);
   }
+
+  /** Absolute path of the on-disk history file for this workspace. */
+  getFilePath(workspacePath: string): string {
+    return this.fileFor(workspacePath);
+  }
+
+  /** Absolute path of the directory holding all workspace history files. */
+  getRootPath(): string {
+    return join(this.rootDir, 'history');
+  }
+
+  /** Drop in-memory cache so the next load re-reads from disk. */
+  invalidateCache(workspacePath?: string): void {
+    if (workspacePath) this.cache.delete(workspacePath);
+    else this.cache.clear();
+  }
 }
 
 // On-disk shape: large bodies stored gzipped to keep history files small.

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -365,6 +365,11 @@ export interface ScrapemanBridge {
   ) => Promise<HistoryEntry[]>;
   historyDelete: (workspacePath: string, id: string) => Promise<void>;
   historyClear: (workspacePath: string) => Promise<void>;
+  historyStats: (
+    workspacePath: string,
+  ) => Promise<{ count: number; diskBytes: number; path: string }>;
+  historyClearAll: () => Promise<void>;
+  openInShell: (path: string) => Promise<void>;
 
   // Cookies
   cookieList: (workspacePath: string) => Promise<CookieEntry[]>;


### PR DESCRIPTION
Kapatır #10.

Header'a gear ikonu eklendi; açılan Settings modal'ında:

- **Storage** — aktif workspace'in history dosya yolu (mono + copy + "Reveal in Finder/Explorer"), entry sayısı ve disk kullanımı, "Clear this workspace" butonu (confirm ile).
- **All workspaces** — "Clear all history" (userData/history altındaki tüm `.jsonl`'leri boşaltır).

Yeni IPC: `history:stats`, `history:clearAll`, `app:openInShell`. `HistoryStore` üzerine `getFilePath` / `getRootPath` / `invalidateCache` yardımcıları eklendi. Clear sonrası sidebar history refresh ediliyor.

MVP kapsamında max-entries / max-age / max-disk config **ertelendi** — takip PR'da gelecek.

## Verify
- `pnpm -r typecheck` OK
- `pnpm -r test` OK (125 test)
- `pnpm --filter=@scrapeman/desktop build` OK