### PR TITLE
feat(http): Postman-parity auto headers

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -31,7 +31,12 @@ import type {
 import { WorkspaceManager } from './workspace-manager.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const executor = new UndiciExecutor();
+const executor = new UndiciExecutor({
+  autoHeaderEnv: {
+    version: app.getVersion(),
+    platform: `${process.platform} ${process.arch}`,
+  },
+});
 const workspaceManager = new WorkspaceManager();
 const oauth2Client = new OAuth2Client();
 let historyStore: HistoryStore | null = null;

--- a/apps/desktop/src/renderer/src/components/AutoHeadersPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/AutoHeadersPanel.tsx
@@ -1,0 +1,132 @@
+import { useMemo, useState } from 'react';
+import type { BuilderState } from '../store.js';
+
+interface PreviewRow {
+  key: string;
+  value: string;
+  readonly?: boolean;
+}
+
+function contentTypeForBuilder(builder: BuilderState): string | null {
+  if (builder.bodyType === 'none' || !builder.body.trim()) return null;
+  if (builder.bodyType === 'json') return 'application/json';
+  if (builder.bodyType === 'text') return 'text/plain';
+  return null;
+}
+
+function previewAutoHeaders(builder: BuilderState): PreviewRow[] {
+  const rows: PreviewRow[] = [
+    { key: 'User-Agent', value: 'Scrapeman/<version> (<platform>)' },
+    { key: 'Accept', value: '*/*' },
+    { key: 'Accept-Encoding', value: 'gzip, deflate, br' },
+    { key: 'Cache-Control', value: 'no-cache' },
+    { key: 'Connection', value: 'keep-alive' },
+    { key: 'X-Scrapeman-Token', value: '<uuid per request>' },
+  ];
+  const ct = contentTypeForBuilder(builder);
+  if (ct) rows.push({ key: 'Content-Type', value: ct });
+  rows.push({ key: 'Host', value: '<from URL>', readonly: true });
+  rows.push({ key: 'Content-Length', value: '<computed>', readonly: true });
+  return rows;
+}
+
+export function AutoHeadersPanel({
+  builder,
+  onChange,
+}: {
+  builder: BuilderState;
+  onChange: (disabled: string[]) => void;
+}): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const rows = useMemo(() => previewAutoHeaders(builder), [builder]);
+  const disabled = useMemo(
+    () => new Set(builder.disabledAutoHeaders.map((k) => k.toLowerCase())),
+    [builder.disabledAutoHeaders],
+  );
+  const userKeys = useMemo(
+    () =>
+      new Set(
+        builder.headers
+          .filter((h) => h.enabled && h.key.trim())
+          .map((h) => h.key.trim().toLowerCase()),
+      ),
+    [builder.headers],
+  );
+
+  const toggle = (key: string): void => {
+    const lower = key.toLowerCase();
+    const next = disabled.has(lower)
+      ? builder.disabledAutoHeaders.filter((k) => k.toLowerCase() !== lower)
+      : [...builder.disabledAutoHeaders, key];
+    onChange(next);
+  };
+
+  return (
+    <div className="border-b border-line bg-bg-subtle/40">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-ink-4 hover:text-ink-2"
+      >
+        <span>Auto Headers ({rows.length})</span>
+        <span>{open ? 'Hide' : 'Show'}</span>
+      </button>
+      {open && (
+        <div className="flex flex-col border-t border-line-subtle">
+          {rows.map((row) => {
+            const lower = row.key.toLowerCase();
+            const isDisabled = disabled.has(lower);
+            const overridden = userKeys.has(lower);
+            const isReadonly = row.readonly === true;
+            return (
+              <div
+                key={row.key}
+                className="grid grid-cols-[32px_1fr_1.5fr_auto] items-center border-b border-line-subtle px-3 py-1"
+              >
+                <div className="flex items-center justify-center">
+                  {isReadonly ? (
+                    <span className="text-ink-4">--</span>
+                  ) : (
+                    <input
+                      type="checkbox"
+                      checked={!isDisabled && !overridden}
+                      disabled={overridden}
+                      onChange={() => toggle(row.key)}
+                      className="h-3.5 w-3.5 cursor-pointer accent-accent disabled:cursor-not-allowed"
+                    />
+                  )}
+                </div>
+                <div
+                  className={`py-1 font-mono text-xs ${
+                    isDisabled || overridden ? 'text-ink-4 line-through' : 'text-ink-2'
+                  }`}
+                >
+                  {row.key}
+                </div>
+                <div className="truncate py-1 font-mono text-xs text-ink-3">
+                  {row.value}
+                </div>
+                <div className="pl-2">
+                  {overridden && (
+                    <span className="rounded bg-accent-soft px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-accent">
+                      overridden
+                    </span>
+                  )}
+                  {!overridden && isReadonly && (
+                    <span className="rounded bg-bg-hover px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-ink-4">
+                      readonly
+                    </span>
+                  )}
+                  {!overridden && !isReadonly && isDisabled && (
+                    <span className="rounded bg-bg-hover px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-ink-4">
+                      disabled
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/RequestBuilder.tsx
+++ b/apps/desktop/src/renderer/src/components/RequestBuilder.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { useAppStore } from '../store.js';
 import { MethodPicker } from './MethodPicker.js';
 import { HeadersEditor } from './HeadersEditor.js';
+import { AutoHeadersPanel } from './AutoHeadersPanel.js';
 import { ParamsEditor } from './ParamsEditor.js';
 import { SettingsTab as SettingsTabPanel } from './SettingsTab.js';
 import { AuthTab } from './AuthTab.js';
@@ -24,6 +25,7 @@ export function RequestBuilder(): JSX.Element {
   const addHeader = useAppStore((s) => s.addHeader);
   const updateHeader = useAppStore((s) => s.updateHeader);
   const removeHeader = useAppStore((s) => s.removeHeader);
+  const setDisabledAutoHeaders = useAppStore((s) => s.setDisabledAutoHeaders);
   const addParam = useAppStore((s) => s.addParam);
   const updateParam = useAppStore((s) => s.updateParam);
   const removeParam = useAppStore((s) => s.removeParam);
@@ -215,12 +217,18 @@ export function RequestBuilder(): JSX.Element {
           />
         )}
         {tab === 'headers' && (
-          <HeadersEditor
-            rows={builder.headers}
-            onAdd={addHeader}
-            onUpdate={updateHeader}
-            onRemove={removeHeader}
-          />
+          <div className="flex flex-col">
+            <AutoHeadersPanel
+              builder={builder}
+              onChange={setDisabledAutoHeaders}
+            />
+            <HeadersEditor
+              rows={builder.headers}
+              onAdd={addHeader}
+              onUpdate={updateHeader}
+              onRemove={removeHeader}
+            />
+          </div>
         )}
         {tab === 'auth' && <AuthTab />}
         {tab === 'settings' && <SettingsTabPanel />}

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -64,6 +64,7 @@ export interface BuilderState {
   bodyType: 'none' | 'json' | 'text';
   auth: AuthConfig;
   settings: SettingsState;
+  disabledAutoHeaders: string[];
 }
 
 export interface ExecutionState {
@@ -143,6 +144,7 @@ interface AppState {
 
   updateSettings: (patch: Partial<SettingsState>) => void;
   setAuth: (auth: AuthConfig) => void;
+  setDisabledAutoHeaders: (keys: string[]) => void;
 
   send: () => Promise<void>;
   cancelSend: () => void;
@@ -317,6 +319,7 @@ function builderFromRequest(request: ScrapemanRequest): BuilderState {
     bodyType,
     auth: request.auth ?? { type: 'none' },
     settings,
+    disabledAutoHeaders: request.disabledAutoHeaders ?? [],
   };
 }
 
@@ -371,6 +374,9 @@ function buildRequest(
     options.httpVersion = s.httpVersion;
   }
   if (Object.keys(options).length > 0) request.options = options;
+  if (builder.disabledAutoHeaders.length > 0) {
+    request.disabledAutoHeaders = [...builder.disabledAutoHeaders];
+  }
 
   return request;
 }
@@ -391,6 +397,7 @@ function emptyDraftTab(): Tab {
       bodyType: 'none',
       auth: { type: 'none' },
       settings: freshSettings(),
+      disabledAutoHeaders: [],
     },
     dirty: false,
     execution: freshExecution(),
@@ -722,6 +729,14 @@ export const useAppStore = create<AppState>((set, get) => {
       }));
     },
 
+    setDisabledAutoHeaders: (keys) => {
+      mutateActive((tab) => ({
+        ...tab,
+        builder: { ...tab.builder, disabledAutoHeaders: keys },
+        dirty: true,
+      }));
+    },
+
     send: async () => {
       const { activeTabId, tabs } = get();
       if (!activeTabId) return;
@@ -981,6 +996,7 @@ export const useAppStore = create<AppState>((set, get) => {
           bodyType,
           auth: { type: 'none' },
           settings: freshSettings(),
+          disabledAutoHeaders: [],
         },
         dirty: false,
         execution,

--- a/packages/http-core/src/adapters/undici-executor.ts
+++ b/packages/http-core/src/adapters/undici-executor.ts
@@ -13,6 +13,7 @@ import type {
 } from '@scrapeman/shared-types';
 import type { RequestExecutor } from '../executor.js';
 import { ExecutorError } from '../errors.js';
+import { buildAutoHeaders, mergeHeaders } from '../auto-headers.js';
 
 const DEFAULT_MAX_REDIRECTS = 10;
 const DEFAULT_TOTAL_TIMEOUT_MS = 120_000;
@@ -22,13 +23,19 @@ const DEFAULT_MAX_RESPONSE_BYTES = 200 * 1024 * 1024; // 200 MB
 
 export interface UndiciExecutorOptions {
   maxResponseBytes?: number;
+  autoHeaderEnv?: { version: string; platform: string };
 }
 
 export class UndiciExecutor implements RequestExecutor {
   private readonly maxResponseBytes: number;
+  private readonly autoHeaderEnv: { version: string; platform: string };
 
   constructor(options: UndiciExecutorOptions = {}) {
     this.maxResponseBytes = options.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+    this.autoHeaderEnv = options.autoHeaderEnv ?? {
+      version: '0.0.0',
+      platform: `${process.platform} ${process.arch}`,
+    };
   }
 
   async execute(
@@ -36,7 +43,9 @@ export class UndiciExecutor implements RequestExecutor {
     options: { signal?: AbortSignal } = {},
   ): Promise<ExecutedResponse> {
     const url = buildUrl(request);
-    const headers = buildHeaders(request);
+    const auto = buildAutoHeaders(request, this.autoHeaderEnv);
+    const disabled = new Set(request.disabledAutoHeaders ?? []);
+    const headers = mergeHeaders(auto, request.headers, disabled);
     const body = buildBody(request.body);
     const totalTimeout = request.options?.timeout?.total ?? DEFAULT_TOTAL_TIMEOUT_MS;
     const followRedirects = request.options?.redirect?.follow ?? true;
@@ -164,16 +173,6 @@ function buildBaseDispatcher(
 function parseProxyScheme(url: string): string {
   const match = /^(\w+):\/\//.exec(url);
   return match?.[1]?.toLowerCase() ?? 'http';
-}
-
-function buildHeaders(request: ScrapemanRequest): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (request.headers) {
-    for (const [key, value] of Object.entries(request.headers)) {
-      headers[key] = value;
-    }
-  }
-  return headers;
 }
 
 function buildBody(body: BodyConfig | undefined): string | Uint8Array | undefined {

--- a/packages/http-core/src/auto-headers.ts
+++ b/packages/http-core/src/auto-headers.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from 'node:crypto';
+import type { BodyConfig, ScrapemanRequest } from '@scrapeman/shared-types';
+
+export interface AutoHeader {
+  key: string;
+  value: string;
+  readonly?: boolean;
+}
+
+export interface AutoHeaderEnv {
+  version: string;
+  platform: string;
+}
+
+export function contentTypeForBody(body: BodyConfig | undefined): string | null {
+  if (!body || body.type === 'none') return null;
+  if (body.type === 'json') return 'application/json';
+  if (body.type === 'xml') return 'application/xml';
+  if (body.type === 'html') return 'text/html';
+  if (body.type === 'javascript') return 'application/javascript';
+  if (body.type === 'text') return 'text/plain';
+  if (body.type === 'formUrlEncoded') return 'application/x-www-form-urlencoded';
+  if (body.type === 'binary') return 'application/octet-stream';
+  // multipart: undici sets the boundary — we stay out of it.
+  return null;
+}
+
+export function buildAutoHeaders(
+  request: ScrapemanRequest,
+  env: AutoHeaderEnv,
+): AutoHeader[] {
+  const headers: AutoHeader[] = [
+    { key: 'User-Agent', value: `Scrapeman/${env.version} (${env.platform})` },
+    { key: 'Accept', value: '*/*' },
+    { key: 'Accept-Encoding', value: 'gzip, deflate, br' },
+    { key: 'Cache-Control', value: 'no-cache' },
+    { key: 'Connection', value: 'keep-alive' },
+    { key: 'X-Scrapeman-Token', value: randomUUID() },
+  ];
+  const ct = contentTypeForBody(request.body);
+  if (ct) headers.push({ key: 'Content-Type', value: ct });
+  return headers;
+}
+
+export function mergeHeaders(
+  auto: AutoHeader[],
+  user: Record<string, string> | undefined,
+  disabled: Set<string>,
+): Record<string, string> {
+  const disabledLower = new Set(
+    Array.from(disabled, (k) => k.toLowerCase()),
+  );
+  const userLowerKeys = new Set<string>();
+  if (user) {
+    for (const key of Object.keys(user)) userLowerKeys.add(key.toLowerCase());
+  }
+
+  const result: Record<string, string> = {};
+  for (const h of auto) {
+    const lower = h.key.toLowerCase();
+    if (disabledLower.has(lower)) continue;
+    if (userLowerKeys.has(lower)) continue; // user wins
+    result[h.key] = h.value;
+  }
+  if (user) {
+    for (const [key, value] of Object.entries(user)) {
+      result[key] = value;
+    }
+  }
+  return result;
+}

--- a/packages/http-core/src/index.ts
+++ b/packages/http-core/src/index.ts
@@ -17,5 +17,6 @@ export * from './auth/index.js';
 export * from './scrapeDo/index.js';
 export * from './cookies/index.js';
 export * from './load/index.js';
+export * from './auto-headers.js';
 
 export type { ScrapemanRequest, ExecutedResponse };

--- a/packages/http-core/tests/auto-headers.test.ts
+++ b/packages/http-core/tests/auto-headers.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildAutoHeaders,
+  contentTypeForBody,
+  mergeHeaders,
+} from '../src/auto-headers.js';
+import { FORMAT_VERSION, type ScrapemanRequest } from '@scrapeman/shared-types';
+
+const ENV = { version: '1.2.3', platform: 'darwin arm64' };
+
+function req(overrides: Partial<ScrapemanRequest> = {}): ScrapemanRequest {
+  return {
+    scrapeman: FORMAT_VERSION,
+    meta: { name: 'test' },
+    method: 'GET',
+    url: 'http://x/',
+    ...overrides,
+  };
+}
+
+describe('buildAutoHeaders', () => {
+  it('includes all canonical auto headers for a bodyless GET', () => {
+    const h = buildAutoHeaders(req(), ENV);
+    const keys = h.map((x) => x.key);
+    expect(keys).toContain('User-Agent');
+    expect(keys).toContain('Accept');
+    expect(keys).toContain('Accept-Encoding');
+    expect(keys).toContain('Cache-Control');
+    expect(keys).toContain('Connection');
+    expect(keys).toContain('X-Scrapeman-Token');
+    expect(keys).not.toContain('Content-Type');
+  });
+
+  it('formats User-Agent as Scrapeman/<version> (<platform>)', () => {
+    const h = buildAutoHeaders(req(), ENV);
+    const ua = h.find((x) => x.key === 'User-Agent');
+    expect(ua?.value).toBe('Scrapeman/1.2.3 (darwin arm64)');
+  });
+
+  it('generates a unique X-Scrapeman-Token per call', () => {
+    const a = buildAutoHeaders(req(), ENV).find((x) => x.key === 'X-Scrapeman-Token');
+    const b = buildAutoHeaders(req(), ENV).find((x) => x.key === 'X-Scrapeman-Token');
+    expect(a?.value).not.toBe(b?.value);
+    expect(a?.value).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it('adds Content-Type for json body', () => {
+    const h = buildAutoHeaders(
+      req({ body: { type: 'json', content: '{}' } }),
+      ENV,
+    );
+    expect(h.find((x) => x.key === 'Content-Type')?.value).toBe('application/json');
+  });
+
+  it('skips Content-Type for multipart bodies', () => {
+    const h = buildAutoHeaders(
+      req({ body: { type: 'multipart', parts: [] } }),
+      ENV,
+    );
+    expect(h.find((x) => x.key === 'Content-Type')).toBeUndefined();
+  });
+});
+
+describe('contentTypeForBody', () => {
+  it('returns null for none/undefined/multipart', () => {
+    expect(contentTypeForBody(undefined)).toBeNull();
+    expect(contentTypeForBody({ type: 'none' })).toBeNull();
+    expect(contentTypeForBody({ type: 'multipart', parts: [] })).toBeNull();
+  });
+
+  it('maps each body type to its expected Content-Type', () => {
+    expect(contentTypeForBody({ type: 'json', content: '' })).toBe('application/json');
+    expect(contentTypeForBody({ type: 'xml', content: '' })).toBe('application/xml');
+    expect(contentTypeForBody({ type: 'html', content: '' })).toBe('text/html');
+    expect(contentTypeForBody({ type: 'javascript', content: '' })).toBe(
+      'application/javascript',
+    );
+    expect(contentTypeForBody({ type: 'text', content: '' })).toBe('text/plain');
+    expect(contentTypeForBody({ type: 'formUrlEncoded', fields: {} })).toBe(
+      'application/x-www-form-urlencoded',
+    );
+    expect(contentTypeForBody({ type: 'binary', file: '/tmp/x' })).toBe(
+      'application/octet-stream',
+    );
+  });
+});
+
+describe('mergeHeaders', () => {
+  it('emits all auto headers when user provides none', () => {
+    const auto = buildAutoHeaders(req(), ENV);
+    const merged = mergeHeaders(auto, undefined, new Set());
+    expect(merged['User-Agent']).toBe('Scrapeman/1.2.3 (darwin arm64)');
+    expect(merged['Accept']).toBe('*/*');
+  });
+
+  it('user header overrides auto header case-insensitively', () => {
+    const auto = buildAutoHeaders(req(), ENV);
+    const merged = mergeHeaders(auto, { 'user-agent': 'curl/8.0' }, new Set());
+    expect(merged['user-agent']).toBe('curl/8.0');
+    expect(merged['User-Agent']).toBeUndefined();
+    // Only one UA is emitted.
+    const uaCount = Object.keys(merged).filter(
+      (k) => k.toLowerCase() === 'user-agent',
+    ).length;
+    expect(uaCount).toBe(1);
+  });
+
+  it('disabled set skips matching auto headers (case-insensitive)', () => {
+    const auto = buildAutoHeaders(req(), ENV);
+    const merged = mergeHeaders(auto, undefined, new Set(['user-agent', 'Accept']));
+    expect(merged['User-Agent']).toBeUndefined();
+    expect(merged['Accept']).toBeUndefined();
+    expect(merged['Cache-Control']).toBe('no-cache');
+  });
+
+  it('user-supplied headers still pass through when their name is disabled', () => {
+    const auto = buildAutoHeaders(req(), ENV);
+    const merged = mergeHeaders(
+      auto,
+      { 'X-Custom': 'yes' },
+      new Set(['user-agent']),
+    );
+    expect(merged['X-Custom']).toBe('yes');
+    expect(merged['User-Agent']).toBeUndefined();
+  });
+
+  it('multipart body: auto Content-Type absent, user can still set one', () => {
+    const auto = buildAutoHeaders(
+      req({ body: { type: 'multipart', parts: [] } }),
+      ENV,
+    );
+    const merged = mergeHeaders(auto, undefined, new Set());
+    expect(
+      Object.keys(merged).find((k) => k.toLowerCase() === 'content-type'),
+    ).toBeUndefined();
+  });
+});

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -113,6 +113,7 @@ export interface ScrapemanRequest {
   proxy?: ProxyConfig;
   scrapeDo?: ScrapeDoConfig;
   options?: RequestOptions;
+  disabledAutoHeaders?: string[];
 }
 
 export interface ResponseTimings {


### PR DESCRIPTION
Kapatır #12.

Postman tarzı auto header sistemi: kullanıcı her request öncesi hangi header'ların otomatik eklendiğini görür, istediğini disable eder ve kendi eklediği header otomatik olanı case-insensitive override eder.

## Kapsam (7 madde)
1. `packages/http-core/src/auto-headers.ts` (yeni) — `buildAutoHeaders`, `contentTypeForBody`, `mergeHeaders`. User-Agent / Accept / Accept-Encoding / Cache-Control / Connection / X-Scrapeman-Token (per-request UUID) + body'den türetilen Content-Type.
2. `packages/shared-types/src/index.ts` — `ScrapemanRequest.disabledAutoHeaders?: string[]` alanı eklendi.
3. `packages/http-core/src/adapters/undici-executor.ts` — `autoHeaderEnv` constructor opsiyonu; her `execute` çağrısında `buildAutoHeaders` + `mergeHeaders` uygulanıyor, böylece executor tek başına kullanıldığında da doğru header'lar gidiyor.
4. `apps/desktop/src/main/index.ts` — `UndiciExecutor` gerçek `app.getVersion()` + `process.platform process.arch` ile kuruluyor; `disabledAutoHeaders` mevcut `ScrapemanRequest` alanı üzerinden doğal olarak geçiyor (variable / auth / scrape-do / cookie çözümleme sırası değişmedi).
5. `apps/desktop/src/renderer/src/components/AutoHeadersPanel.tsx` (yeni) — Headers tab'ının üstünde collapsible panel; her satır için toggle, user header varsa "overridden" badge, Host + Content-Length readonly.
6. `apps/desktop/src/renderer/src/store.ts` — `BuilderState.disabledAutoHeaders` + `setDisabledAutoHeaders` action; `buildRequest` serialize sırasında request'e ekliyor.
7. `packages/http-core/tests/auto-headers.test.ts` (yeni) — 12 vitest case: her header'ın varlığı, User-Agent formatı, UUID uniqueness, Content-Type tablosu, multipart skip, user override case-insensitive, disabled set, user+disabled kombinasyonu.

## Test sonucu
- `pnpm -r typecheck` — temiz
- `pnpm -r test` — **137 passed** (12 yeni)
- `pnpm --filter=@scrapeman/desktop build` — başarılı

## Notlar / judgment calls
- **`decompress: true` atlandı**: kurulu undici `7.25.0` sürümü `request()` için `decompress` opsiyonunu kabul etmiyor (`node_modules/undici/types` içinde böyle bir alan yok). Accept-Encoding header'ı yine de gönderiliyor; response decompress otomatik değil. Upgrade sonrası tek satırla eklenebilir.
- Auto header merge executor içine kondu (defense-in-depth). Desktop main process gerçek version/platform'u constructor üzerinden geçiriyor, böylece preview panel dışındaki tüm request path'ler aynı logic'i kullanıyor.
- `X-Scrapeman-Token` UI preview'ında `<uuid per request>` placeholder gösteriliyor — gerçek değer her request'te yeniden üretiliyor.