### PR TITLE
feat(git): in-app source control panel

### DIFF
--- a/apps/desktop/src/main/git.ts
+++ b/apps/desktop/src/main/git.ts
@@ -1,0 +1,203 @@
+// Thin wrapper around the git binary. All git calls use execFile with
+// array args so nothing is ever shell-parsed — safe against paths with
+// spaces or shell metacharacters. Parsing of status output lives in
+// @scrapeman/http-core (pure function, independently tested).
+
+import { execFile } from 'node:child_process';
+import { promises as fsp } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { parsePorcelainStatus } from '@scrapeman/http-core';
+import type { GitFileChange, GitStatus } from '@scrapeman/shared-types';
+
+const execFileAsync = promisify(execFile);
+
+export class GitError extends Error {
+  constructor(
+    message: string,
+    public readonly stderr: string,
+    public readonly code: number | null,
+  ) {
+    super(message);
+    this.name = 'GitError';
+  }
+}
+
+async function run(
+  cwd: string,
+  args: string[],
+  opts: { maxBuffer?: number } = {},
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    const { stdout, stderr } = await execFileAsync('git', args, {
+      cwd,
+      maxBuffer: opts.maxBuffer ?? 16 * 1024 * 1024,
+      // Inherit env; rely on the user's credential helper for push/pull.
+    });
+    return { stdout, stderr };
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException & {
+      stdout?: string;
+      stderr?: string;
+      code?: number | string;
+    };
+    const stderr = typeof e.stderr === 'string' ? e.stderr : '';
+    const message = stderr.trim() || e.message || 'git command failed';
+    const code = typeof e.code === 'number' ? e.code : null;
+    throw new GitError(message, stderr, code);
+  }
+}
+
+async function isInsideWorkTree(cwd: string): Promise<boolean> {
+  try {
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', '--is-inside-work-tree'],
+      { cwd },
+    );
+    return stdout.trim() === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export async function gitStatus(workspacePath: string): Promise<GitStatus> {
+  const isRepo = await isInsideWorkTree(workspacePath);
+  if (!isRepo) {
+    return { isRepo: false, branch: null, ahead: 0, behind: 0, changes: [] };
+  }
+  const { stdout } = await run(workspacePath, [
+    'status',
+    '--porcelain=v1',
+    '-b',
+    '-z',
+    '--untracked-files=all',
+  ]);
+  const parsed = parsePorcelainStatus(stdout);
+  const changes: GitFileChange[] = parsed.changes.map((c) => ({
+    path: c.path,
+    status: c.status,
+    staged: c.staged,
+    ...(c.originalPath ? { originalPath: c.originalPath } : {}),
+  }));
+  return {
+    isRepo: true,
+    branch: parsed.branch,
+    ahead: parsed.ahead,
+    behind: parsed.behind,
+    changes,
+  };
+}
+
+export async function gitDiff(
+  workspacePath: string,
+  relPath: string,
+  options: { staged: boolean },
+): Promise<string> {
+  const args = ['diff', '--no-color'];
+  if (options.staged) args.push('--cached');
+  args.push('--', relPath);
+  const { stdout } = await run(workspacePath, args);
+  if (stdout.trim().length > 0) return stdout;
+
+  // Untracked files don't appear in `git diff` at all — synthesise a
+  // pseudo-diff so the UI can still render a useful preview.
+  if (!options.staged) {
+    try {
+      const content = await fsp.readFile(join(workspacePath, relPath), 'utf8');
+      const lines = content.split('\n');
+      const header = `diff --git a/${relPath} b/${relPath}\nnew file\n--- /dev/null\n+++ b/${relPath}\n`;
+      return header + lines.map((l) => `+${l}`).join('\n');
+    } catch {
+      return '';
+    }
+  }
+  return '';
+}
+
+export async function gitStage(
+  workspacePath: string,
+  relPath: string,
+): Promise<void> {
+  await run(workspacePath, ['add', '--', relPath]);
+}
+
+export async function gitUnstage(
+  workspacePath: string,
+  relPath: string,
+): Promise<void> {
+  // `git restore --staged` is the modern equivalent of `reset HEAD --`
+  // and works on repos without any commits (where HEAD does not resolve).
+  try {
+    await run(workspacePath, ['restore', '--staged', '--', relPath]);
+  } catch {
+    // Fallback for pre-2.23 git.
+    await run(workspacePath, ['reset', 'HEAD', '--', relPath]);
+  }
+}
+
+export async function gitDiscard(
+  workspacePath: string,
+  relPath: string,
+): Promise<void> {
+  // Figure out whether this path is tracked; if not, delete it from disk.
+  try {
+    await run(workspacePath, [
+      'ls-files',
+      '--error-unmatch',
+      '--',
+      relPath,
+    ]);
+    await run(workspacePath, ['checkout', 'HEAD', '--', relPath]);
+  } catch {
+    // Untracked — remove from worktree.
+    try {
+      await fsp.rm(join(workspacePath, relPath), { force: true });
+    } catch (err) {
+      throw new GitError(
+        `Failed to remove ${relPath}`,
+        err instanceof Error ? err.message : String(err),
+        null,
+      );
+    }
+  }
+}
+
+export async function gitCommit(
+  workspacePath: string,
+  message: string,
+): Promise<void> {
+  if (!message.trim()) {
+    throw new GitError('Commit message is required', '', null);
+  }
+  await run(workspacePath, ['commit', '-m', message]);
+}
+
+export async function gitPush(
+  workspacePath: string,
+): Promise<{ ok: boolean; message?: string }> {
+  try {
+    const { stdout, stderr } = await run(workspacePath, ['push']);
+    return { ok: true, message: (stderr || stdout).trim() };
+  } catch (err) {
+    const message =
+      err instanceof GitError ? err.message : (err as Error).message;
+    return { ok: false, message };
+  }
+}
+
+export async function gitPull(
+  workspacePath: string,
+): Promise<{ ok: boolean; message?: string }> {
+  try {
+    const { stdout, stderr } = await run(workspacePath, [
+      'pull',
+      '--ff-only',
+    ]);
+    return { ok: true, message: (stderr || stdout).trim() };
+  } catch (err) {
+    const message =
+      err instanceof GitError ? err.message : (err as Error).message;
+    return { ok: false, message };
+  }
+}

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -31,6 +31,17 @@ import type {
   ScrapemanRequest,
 } from '@scrapeman/shared-types';
 import { WorkspaceManager } from './workspace-manager.js';
+import {
+  gitStatus,
+  gitDiff,
+  gitStage,
+  gitUnstage,
+  gitDiscard,
+  gitCommit,
+  gitPush,
+  gitPull,
+  GitError,
+} from './git.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const executor = new UndiciExecutor({
@@ -517,6 +528,81 @@ app.whenReady().then(() => {
     'workspace:move',
     (_e, path: string, relPath: string, newParent: string) =>
       workspaceManager.move(path, relPath, newParent),
+  );
+
+  const toGitError = (err: unknown): Error => {
+    if (err instanceof GitError) return err;
+    if (err instanceof Error) return err;
+    return new Error(String(err));
+  };
+
+  ipcMain.handle('git:status', async (_e, workspacePath: string) => {
+    try {
+      return await gitStatus(workspacePath);
+    } catch (err) {
+      throw toGitError(err);
+    }
+  });
+  ipcMain.handle(
+    'git:diff',
+    async (
+      _e,
+      workspacePath: string,
+      relPath: string,
+      options: { staged: boolean },
+    ) => {
+      try {
+        return await gitDiff(workspacePath, relPath, options);
+      } catch (err) {
+        throw toGitError(err);
+      }
+    },
+  );
+  ipcMain.handle(
+    'git:stage',
+    async (_e, workspacePath: string, relPath: string) => {
+      try {
+        await gitStage(workspacePath, relPath);
+      } catch (err) {
+        throw toGitError(err);
+      }
+    },
+  );
+  ipcMain.handle(
+    'git:unstage',
+    async (_e, workspacePath: string, relPath: string) => {
+      try {
+        await gitUnstage(workspacePath, relPath);
+      } catch (err) {
+        throw toGitError(err);
+      }
+    },
+  );
+  ipcMain.handle(
+    'git:discard',
+    async (_e, workspacePath: string, relPath: string) => {
+      try {
+        await gitDiscard(workspacePath, relPath);
+      } catch (err) {
+        throw toGitError(err);
+      }
+    },
+  );
+  ipcMain.handle(
+    'git:commit',
+    async (_e, workspacePath: string, message: string) => {
+      try {
+        await gitCommit(workspacePath, message);
+      } catch (err) {
+        throw toGitError(err);
+      }
+    },
+  );
+  ipcMain.handle('git:push', (_e, workspacePath: string) =>
+    gitPush(workspacePath),
+  );
+  ipcMain.handle('git:pull', (_e, workspacePath: string) =>
+    gitPull(workspacePath),
   );
 
   ipcMain.handle('env:list', (_e, workspacePath: string) =>

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -4,6 +4,8 @@ import type {
   CookieEntry,
   Environment,
   ExecuteResult,
+  GitOpResult,
+  GitStatus,
   HistoryEntry,
   HistoryListOptions,
   ImportCurlResult,
@@ -165,6 +167,32 @@ const api: ScrapemanBridge = {
     ipcRenderer.on('workspace:event', listener);
     return () => ipcRenderer.off('workspace:event', listener);
   },
+
+  gitStatus: (workspacePath: string) =>
+    ipcRenderer.invoke('git:status', workspacePath) as Promise<GitStatus>,
+  gitDiff: (
+    workspacePath: string,
+    relPath: string,
+    options: { staged: boolean },
+  ) =>
+    ipcRenderer.invoke(
+      'git:diff',
+      workspacePath,
+      relPath,
+      options,
+    ) as Promise<string>,
+  gitStage: (workspacePath: string, relPath: string) =>
+    ipcRenderer.invoke('git:stage', workspacePath, relPath) as Promise<void>,
+  gitUnstage: (workspacePath: string, relPath: string) =>
+    ipcRenderer.invoke('git:unstage', workspacePath, relPath) as Promise<void>,
+  gitDiscard: (workspacePath: string, relPath: string) =>
+    ipcRenderer.invoke('git:discard', workspacePath, relPath) as Promise<void>,
+  gitCommit: (workspacePath: string, message: string) =>
+    ipcRenderer.invoke('git:commit', workspacePath, message) as Promise<void>,
+  gitPush: (workspacePath: string) =>
+    ipcRenderer.invoke('git:push', workspacePath) as Promise<GitOpResult>,
+  gitPull: (workspacePath: string) =>
+    ipcRenderer.invoke('git:pull', workspacePath) as Promise<GitOpResult>,
 };
 
 contextBridge.exposeInMainWorld('scrapeman', api);

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import type { CollectionNode } from '@scrapeman/shared-types';
+import { useMemo, useState } from 'react';
+import type { CollectionNode, GitFileChangeStatus } from '@scrapeman/shared-types';
 import { useAppStore } from '../store.js';
 import {
   ContextMenu,
@@ -10,6 +10,7 @@ import {
 } from '../ui/ContextMenu.js';
 import { ConfirmDialog, PromptDialog } from '../ui/Dialog.js';
 import { HistoryPanel } from './HistoryPanel.js';
+import { SourceControlPanel } from './SourceControlPanel.js';
 import { SplitPane } from './SplitPane.js';
 
 const METHOD_COLOR: Record<string, string> = {
@@ -21,6 +22,24 @@ const METHOD_COLOR: Record<string, string> = {
   HEAD: 'text-method-head',
   OPTIONS: 'text-method-options',
 };
+
+const GIT_STATUS_BADGE: Record<GitFileChangeStatus, string> = {
+  modified: 'M',
+  added: 'A',
+  deleted: 'D',
+  untracked: 'U',
+  renamed: 'R',
+};
+
+const GIT_STATUS_COLOR: Record<GitFileChangeStatus, string> = {
+  modified: 'text-method-put',
+  added: 'text-method-post',
+  deleted: 'text-method-delete',
+  untracked: 'text-method-patch',
+  renamed: 'text-method-options',
+};
+
+type SidebarView = 'files' | 'git';
 
 type DialogState =
   | { kind: 'none' }
@@ -37,8 +56,23 @@ export function Sidebar(): JSX.Element {
   const createFolder = useAppStore((s) => s.createFolder);
   const renameNode = useAppStore((s) => s.renameNode);
   const deleteNode = useAppStore((s) => s.deleteNode);
+  const gitStatus = useAppStore((s) => s.gitStatus);
 
   const [dialog, setDialog] = useState<DialogState>({ kind: 'none' });
+  const [view, setView] = useState<SidebarView>('files');
+
+  const gitStatusByPath = useMemo(() => {
+    const map = new Map<string, GitFileChangeStatus>();
+    if (!gitStatus) return map;
+    // Prefer the worktree status (unstaged) for badges, but fall back to
+    // staged if the file is only staged — matches VS Code behaviour.
+    for (const change of gitStatus.changes) {
+      if (!map.has(change.path) || !change.staged) {
+        map.set(change.path, change.status);
+      }
+    }
+    return map;
+  }, [gitStatus]);
 
   if (!workspace || !root) {
     return (
@@ -64,75 +98,51 @@ export function Sidebar(): JSX.Element {
 
   const closeDialog = (): void => setDialog({ kind: 'none' });
 
+  const dirtyCount = gitStatus?.changes.length ?? 0;
+
   return (
     <div className="flex h-full flex-col">
-      <div className="flex h-10 items-center gap-1 border-b border-line px-2">
-        <div className="flex-1 truncate px-1.5 text-xs font-semibold text-ink-1">
-          {workspace.name}
+      <div className="flex h-8 items-stretch border-b border-line">
+        <button
+          onClick={() => setView('files')}
+          className={`flex-1 border-b-2 text-[11px] font-semibold uppercase tracking-wide ${
+            view === 'files'
+              ? 'border-accent text-ink-1'
+              : 'border-transparent text-ink-3 hover:text-ink-1'
+          }`}
+        >
+          Files
+        </button>
+        <button
+          onClick={() => setView('git')}
+          className={`relative flex-1 border-b-2 text-[11px] font-semibold uppercase tracking-wide ${
+            view === 'git'
+              ? 'border-accent text-ink-1'
+              : 'border-transparent text-ink-3 hover:text-ink-1'
+          }`}
+          title="Source Control"
+        >
+          ⎇ Git
+          {dirtyCount > 0 && (
+            <span className="ml-1 text-[10px] text-accent">●{dirtyCount}</span>
+          )}
+        </button>
+      </div>
+      {view === 'git' ? (
+        <div className="min-h-0 flex-1">
+          <SourceControlPanel />
         </div>
-        <button
-          title="New request"
-          onClick={() => setDialog({ kind: 'newRequest', parent: '' })}
-          className="icon-btn"
-        >
-          +
-        </button>
-        <button
-          title="New folder"
-          onClick={() => setDialog({ kind: 'newFolder', parent: '' })}
-          className="icon-btn"
-        >
-          ⌸
-        </button>
-        <button
-          title="Switch workspace"
-          onClick={() => void pickAndOpenWorkspace()}
-          className="icon-btn"
-        >
-          ⇄
-        </button>
-      </div>
-      <div className="flex-1 overflow-hidden">
-        <SplitPane
-          orientation="vertical"
-          initialSize={65}
-          minSize={20}
-          maxSize={85}
-          storageKey="sidebar/history"
-          first={
-            <div className="h-full overflow-auto py-1">
-              {root.children.length === 0 ? (
-                <div className="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center">
-                  <div className="text-xs text-ink-3">This workspace is empty.</div>
-                  <button
-                    onClick={() => setDialog({ kind: 'newRequest', parent: '' })}
-                    className="btn-ghost text-accent hover:text-accent-hover"
-                  >
-                    Create your first request
-                  </button>
-                </div>
-              ) : (
-                root.children.map((child) => (
-                  <TreeNode
-                    key={child.id}
-                    node={child}
-                    depth={0}
-                    onNewRequest={(parent) => setDialog({ kind: 'newRequest', parent })}
-                    onNewFolder={(parent) => setDialog({ kind: 'newFolder', parent })}
-                    onRename={(relPath, currentName) =>
-                      setDialog({ kind: 'rename', relPath, currentName })
-                    }
-                    onDelete={(relPath, name) =>
-                      setDialog({ kind: 'delete', relPath, name })
-                    }
-                  />
-                ))
-              )}
-            </div>
-          }
-          second={<HistoryPanel />}
+      ) : (
+        <FilesView
+          workspaceName={workspace.name}
+          onNewRequest={() => setDialog({ kind: 'newRequest', parent: '' })}
+          onNewFolder={() => setDialog({ kind: 'newFolder', parent: '' })}
+          onPick={() => void pickAndOpenWorkspace()}
+          root={root}
+          gitStatusByPath={gitStatusByPath}
+          setDialog={setDialog}
         />
-      </div>
+      )}
 
       <PromptDialog
         open={dialog.kind === 'newRequest'}
@@ -184,9 +194,91 @@ export function Sidebar(): JSX.Element {
   );
 }
 
+interface FilesViewProps {
+  workspaceName: string;
+  onNewRequest: () => void;
+  onNewFolder: () => void;
+  onPick: () => void;
+  root: NonNullable<ReturnType<typeof useAppStore.getState>['root']>;
+  gitStatusByPath: Map<string, GitFileChangeStatus>;
+  setDialog: (dialog: DialogState) => void;
+}
+
+function FilesView({
+  workspaceName,
+  onNewRequest,
+  onNewFolder,
+  onPick,
+  root,
+  gitStatusByPath,
+  setDialog,
+}: FilesViewProps): JSX.Element {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-10 items-center gap-1 border-b border-line px-2">
+        <div className="flex-1 truncate px-1.5 text-xs font-semibold text-ink-1">
+          {workspaceName}
+        </div>
+        <button title="New request" onClick={onNewRequest} className="icon-btn">
+          +
+        </button>
+        <button title="New folder" onClick={onNewFolder} className="icon-btn">
+          ⌸
+        </button>
+        <button title="Switch workspace" onClick={onPick} className="icon-btn">
+          ⇄
+        </button>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        <SplitPane
+          orientation="vertical"
+          initialSize={65}
+          minSize={20}
+          maxSize={85}
+          storageKey="sidebar/history"
+          first={
+            <div className="h-full overflow-auto py-1">
+              {root.children.length === 0 ? (
+                <div className="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center">
+                  <div className="text-xs text-ink-3">This workspace is empty.</div>
+                  <button
+                    onClick={() => setDialog({ kind: 'newRequest', parent: '' })}
+                    className="btn-ghost text-accent hover:text-accent-hover"
+                  >
+                    Create your first request
+                  </button>
+                </div>
+              ) : (
+                root.children.map((child) => (
+                  <TreeNode
+                    key={child.id}
+                    node={child}
+                    depth={0}
+                    gitStatusByPath={gitStatusByPath}
+                    onNewRequest={(parent) => setDialog({ kind: 'newRequest', parent })}
+                    onNewFolder={(parent) => setDialog({ kind: 'newFolder', parent })}
+                    onRename={(relPath, currentName) =>
+                      setDialog({ kind: 'rename', relPath, currentName })
+                    }
+                    onDelete={(relPath, name) =>
+                      setDialog({ kind: 'delete', relPath, name })
+                    }
+                  />
+                ))
+              )}
+            </div>
+          }
+          second={<HistoryPanel />}
+        />
+      </div>
+    </div>
+  );
+}
+
 interface TreeNodeProps {
   node: CollectionNode;
   depth: number;
+  gitStatusByPath: Map<string, GitFileChangeStatus>;
   onNewRequest: (parent: string) => void;
   onNewFolder: (parent: string) => void;
   onRename: (relPath: string, currentName: string) => void;
@@ -196,6 +288,7 @@ interface TreeNodeProps {
 function TreeNode({
   node,
   depth,
+  gitStatusByPath,
   onNewRequest,
   onNewFolder,
   onRename,
@@ -255,6 +348,7 @@ function TreeNode({
               key={child.id}
               node={child}
               depth={depth + 1}
+              gitStatusByPath={gitStatusByPath}
               onNewRequest={onNewRequest}
               onNewFolder={onNewFolder}
               onRename={onRename}
@@ -288,6 +382,21 @@ function TreeNode({
             {node.method.slice(0, 6)}
           </span>
           <span className="flex-1 truncate">{node.name}</span>
+          {(() => {
+            const gitStatus =
+              node.kind === 'request'
+                ? gitStatusByPath.get(node.relPath)
+                : undefined;
+            if (!gitStatus) return null;
+            return (
+              <span
+                title={`Git: ${gitStatus}`}
+                className={`w-3 text-center font-mono text-[10px] font-semibold ${GIT_STATUS_COLOR[gitStatus]}`}
+              >
+                {GIT_STATUS_BADGE[gitStatus]}
+              </span>
+            );
+          })()}
           {dirty && (
             <span
               title="Unsaved changes"

--- a/apps/desktop/src/renderer/src/components/SourceControlPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/SourceControlPanel.tsx
@@ -1,0 +1,367 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { GitFileChange } from '@scrapeman/shared-types';
+import { useAppStore } from '../store.js';
+import { bridge } from '../bridge.js';
+import { ConfirmDialog } from '../ui/Dialog.js';
+
+const STATUS_BADGE: Record<GitFileChange['status'], string> = {
+  modified: 'M',
+  added: 'A',
+  deleted: 'D',
+  untracked: 'U',
+  renamed: 'R',
+};
+
+const STATUS_CLASS: Record<GitFileChange['status'], string> = {
+  modified: 'text-method-put',
+  added: 'text-method-post',
+  deleted: 'text-method-delete',
+  untracked: 'text-method-patch',
+  renamed: 'text-method-options',
+};
+
+interface SelectedFile {
+  relPath: string;
+  staged: boolean;
+}
+
+export function SourceControlPanel(): JSX.Element {
+  const workspace = useAppStore((s) => s.workspace);
+  const gitStatus = useAppStore((s) => s.gitStatus);
+  const gitError = useAppStore((s) => s.gitError);
+  const gitBusy = useAppStore((s) => s.gitBusy);
+  const loadGitStatus = useAppStore((s) => s.loadGitStatus);
+  const stageFile = useAppStore((s) => s.stageFile);
+  const unstageFile = useAppStore((s) => s.unstageFile);
+  const discardFile = useAppStore((s) => s.discardFile);
+  const commitChanges = useAppStore((s) => s.commitChanges);
+  const gitPush = useAppStore((s) => s.gitPush);
+  const gitPull = useAppStore((s) => s.gitPull);
+
+  const [message, setMessage] = useState('');
+  const [selected, setSelected] = useState<SelectedFile | null>(null);
+  const [diff, setDiff] = useState<string>('');
+  const [confirmDiscard, setConfirmDiscard] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (workspace) void loadGitStatus();
+  }, [workspace, loadGitStatus]);
+
+  useEffect(() => {
+    if (!selected || !workspace) {
+      setDiff('');
+      return;
+    }
+    let cancelled = false;
+    void bridge
+      .gitDiff(workspace.path, selected.relPath, { staged: selected.staged })
+      .then((out) => {
+        if (!cancelled) setDiff(out);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled)
+          setDiff(err instanceof Error ? `# ${err.message}` : String(err));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selected, workspace, gitStatus]);
+
+  const staged = useMemo(
+    () => gitStatus?.changes.filter((c) => c.staged) ?? [],
+    [gitStatus],
+  );
+  const unstaged = useMemo(
+    () => gitStatus?.changes.filter((c) => !c.staged) ?? [],
+    [gitStatus],
+  );
+
+  if (!workspace) {
+    return (
+      <div className="flex h-full items-center justify-center px-6 text-center text-xs text-ink-3">
+        Open a workspace to use source control.
+      </div>
+    );
+  }
+
+  if (!gitStatus) {
+    return (
+      <div className="flex h-full items-center justify-center px-6 text-center text-xs text-ink-3">
+        Loading git status…
+      </div>
+    );
+  }
+
+  if (!gitStatus.isRepo) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+        <div className="text-sm font-semibold text-ink-1">
+          Not a git repository
+        </div>
+        <div className="text-xs text-ink-3">
+          Run <span className="font-mono">git init</span> in your workspace
+          folder to enable source control.
+        </div>
+        <button
+          onClick={() => void loadGitStatus()}
+          className="btn-ghost text-accent hover:text-accent-hover"
+        >
+          Refresh
+        </button>
+      </div>
+    );
+  }
+
+  const canCommit = staged.length > 0 && message.trim().length > 0;
+
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-10 items-center gap-1 border-b border-line px-2">
+        <div className="flex-1 truncate px-1.5 text-xs font-semibold text-ink-1">
+          ⎇ {gitStatus.branch ?? '(detached)'}
+          {gitStatus.changes.length > 0 && (
+            <span className="ml-1.5 text-ink-3">
+              ●{gitStatus.changes.length}
+            </span>
+          )}
+        </div>
+        <button
+          title="Pull"
+          disabled={gitBusy}
+          onClick={() => void gitPull()}
+          className="icon-btn disabled:opacity-50"
+        >
+          ↓{gitStatus.behind > 0 ? gitStatus.behind : ''}
+        </button>
+        <button
+          title="Push"
+          disabled={gitBusy}
+          onClick={() => void gitPush()}
+          className="icon-btn disabled:opacity-50"
+        >
+          ↑{gitStatus.ahead > 0 ? gitStatus.ahead : ''}
+        </button>
+        <button
+          title="Refresh"
+          onClick={() => void loadGitStatus()}
+          className="icon-btn"
+        >
+          ↻
+        </button>
+      </div>
+
+      {gitError && (
+        <div className="border-b border-line bg-bg-hover px-3 py-2 text-[11px] text-method-delete">
+          {gitError}
+        </div>
+      )}
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="border-b border-line p-2">
+          <textarea
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            placeholder="Commit message (⌘Enter to commit)"
+            rows={2}
+            className="w-full resize-none rounded-md border border-line bg-bg-canvas px-2 py-1.5 text-xs text-ink-1 outline-none focus:border-accent"
+            onKeyDown={(e) => {
+              if ((e.metaKey || e.ctrlKey) && e.key === 'Enter' && canCommit) {
+                e.preventDefault();
+                void commitChanges(message).then(() => setMessage(''));
+              }
+            }}
+          />
+          <button
+            disabled={!canCommit}
+            onClick={() => void commitChanges(message).then(() => setMessage(''))}
+            className="btn-primary mt-2 w-full text-xs disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Commit {staged.length > 0 ? `(${staged.length})` : ''}
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto">
+          {staged.length > 0 && (
+            <Section label={`Staged Changes (${staged.length})`}>
+              {staged.map((c) => (
+                <FileRow
+                  key={`s:${c.path}`}
+                  change={c}
+                  active={
+                    selected?.relPath === c.path && selected.staged === true
+                  }
+                  onClick={() =>
+                    setSelected({ relPath: c.path, staged: true })
+                  }
+                  actions={
+                    <button
+                      title="Unstage"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void unstageFile(c.path);
+                      }}
+                      className="icon-btn"
+                    >
+                      −
+                    </button>
+                  }
+                />
+              ))}
+            </Section>
+          )}
+
+          {unstaged.length > 0 && (
+            <Section label={`Changes (${unstaged.length})`}>
+              {unstaged.map((c) => (
+                <FileRow
+                  key={`u:${c.path}`}
+                  change={c}
+                  active={
+                    selected?.relPath === c.path && selected.staged === false
+                  }
+                  onClick={() =>
+                    setSelected({ relPath: c.path, staged: false })
+                  }
+                  actions={
+                    <>
+                      <button
+                        title="Discard"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setConfirmDiscard(c.path);
+                        }}
+                        className="icon-btn"
+                      >
+                        ⟲
+                      </button>
+                      <button
+                        title="Stage"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void stageFile(c.path);
+                        }}
+                        className="icon-btn"
+                      >
+                        +
+                      </button>
+                    </>
+                  }
+                />
+              ))}
+            </Section>
+          )}
+
+          {gitStatus.changes.length === 0 && (
+            <div className="px-3 py-6 text-center text-xs text-ink-3">
+              No changes.
+            </div>
+          )}
+        </div>
+
+        {selected && (
+          <div className="max-h-[40%] min-h-[120px] overflow-auto border-t border-line bg-bg-canvas">
+            <div className="sticky top-0 border-b border-line bg-bg-subtle px-3 py-1.5 text-[11px] font-semibold text-ink-2">
+              {selected.staged ? 'Staged — ' : ''}
+              {selected.relPath}
+            </div>
+            <DiffView diff={diff} />
+          </div>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={confirmDiscard !== null}
+        title="Discard changes"
+        description={
+          confirmDiscard
+            ? `Discard all changes to "${confirmDiscard}"? This cannot be undone.`
+            : ''
+        }
+        confirmLabel="Discard"
+        destructive
+        onConfirm={() => {
+          if (confirmDiscard) void discardFile(confirmDiscard);
+        }}
+        onClose={() => setConfirmDiscard(null)}
+      />
+    </div>
+  );
+}
+
+function Section({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <div>
+      <div className="sticky top-0 z-10 border-b border-line bg-bg-subtle px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-ink-3">
+        {label}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}
+
+function FileRow({
+  change,
+  active,
+  onClick,
+  actions,
+}: {
+  change: GitFileChange;
+  active: boolean;
+  onClick: () => void;
+  actions: React.ReactNode;
+}): JSX.Element {
+  return (
+    <button
+      onClick={onClick}
+      className={`group flex h-7 w-full items-center gap-2 pr-2 pl-3 text-left text-xs ${
+        active ? 'bg-accent-soft text-ink-1' : 'text-ink-2 hover:bg-bg-hover'
+      }`}
+    >
+      <span className="flex-1 truncate">{change.path}</span>
+      <span className="flex items-center gap-1 opacity-0 group-hover:opacity-100">
+        {actions}
+      </span>
+      <span
+        className={`w-4 text-center font-mono text-[10px] font-semibold ${STATUS_CLASS[change.status]}`}
+      >
+        {STATUS_BADGE[change.status]}
+      </span>
+    </button>
+  );
+}
+
+function DiffView({ diff }: { diff: string }): JSX.Element {
+  if (!diff.trim()) {
+    return (
+      <div className="px-3 py-3 text-[11px] text-ink-3">No diff available.</div>
+    );
+  }
+  const lines = diff.split('\n');
+  return (
+    <pre className="px-3 py-2 font-mono text-[11px] leading-[1.45]">
+      {lines.map((line, i) => {
+        let cls = 'text-ink-2';
+        if (line.startsWith('+++') || line.startsWith('---')) {
+          cls = 'text-ink-3';
+        } else if (line.startsWith('+')) {
+          cls = 'text-method-post';
+        } else if (line.startsWith('-')) {
+          cls = 'text-method-delete';
+        } else if (line.startsWith('@@')) {
+          cls = 'text-method-options';
+        }
+        return (
+          <div key={i} className={cls}>
+            {line || '\u00a0'}
+          </div>
+        );
+      })}
+    </pre>
+  );
+}

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -6,6 +6,7 @@ import type {
   Environment,
   EnvironmentVariable,
   ExecutedResponse,
+  GitStatus,
   HistoryEntry,
   HttpMethod,
   HttpVersion,
@@ -172,6 +173,18 @@ interface AppState {
   createFolder: (parentRelPath: string, name: string) => Promise<void>;
   renameNode: (relPath: string, newName: string) => Promise<void>;
   deleteNode: (relPath: string) => Promise<void>;
+
+  // Git
+  gitStatus: GitStatus | null;
+  gitError: string | null;
+  gitBusy: boolean;
+  loadGitStatus: () => Promise<void>;
+  stageFile: (relPath: string) => Promise<void>;
+  unstageFile: (relPath: string) => Promise<void>;
+  discardFile: (relPath: string) => Promise<void>;
+  commitChanges: (message: string) => Promise<void>;
+  gitPush: () => Promise<void>;
+  gitPull: () => Promise<void>;
 }
 
 function freshHeader(): HeaderRow {
@@ -453,6 +466,9 @@ export const useAppStore = create<AppState>((set, get) => {
     history: [],
     tabs: [],
     activeTabId: null,
+    gitStatus: null,
+    gitError: null,
+    gitBusy: false,
     saveDialogOpen: false,
     focusUrlTick: 0,
     importCurlTick: 0,
@@ -478,10 +494,13 @@ export const useAppStore = create<AppState>((set, get) => {
         environments: [],
         activeEnvironment: null,
         history: [],
+        gitStatus: null,
+        gitError: null,
       });
       await get().loadRecents();
       await get().loadEnvironments();
       await get().loadHistory();
+      await get().loadGitStatus();
     },
 
     refreshTree: async () => {
@@ -578,6 +597,7 @@ export const useAppStore = create<AppState>((set, get) => {
       await bridge.workspaceWriteRequest(workspace.path, tab.relPath, request);
       mutateActive((t) => ({ ...t, dirty: false, method: t.builder.method }));
       await get().refreshTree();
+      void get().loadGitStatus();
     },
 
     openSaveDialog: () => set({ saveDialogOpen: true }),
@@ -1024,6 +1044,90 @@ export const useAppStore = create<AppState>((set, get) => {
       };
 
       set({ tabs: [...get().tabs, tab], activeTabId: tab.id });
+    },
+
+    loadGitStatus: async () => {
+      const workspace = get().workspace;
+      if (!workspace) {
+        set({ gitStatus: null });
+        return;
+      }
+      try {
+        const status = await bridge.gitStatus(workspace.path);
+        set({ gitStatus: status, gitError: null });
+      } catch (err) {
+        set({ gitError: err instanceof Error ? err.message : String(err) });
+      }
+    },
+
+    stageFile: async (relPath: string) => {
+      const workspace = get().workspace;
+      if (!workspace) return;
+      try {
+        await bridge.gitStage(workspace.path, relPath);
+        await get().loadGitStatus();
+      } catch (err) {
+        set({ gitError: err instanceof Error ? err.message : String(err) });
+      }
+    },
+
+    unstageFile: async (relPath: string) => {
+      const workspace = get().workspace;
+      if (!workspace) return;
+      try {
+        await bridge.gitUnstage(workspace.path, relPath);
+        await get().loadGitStatus();
+      } catch (err) {
+        set({ gitError: err instanceof Error ? err.message : String(err) });
+      }
+    },
+
+    discardFile: async (relPath: string) => {
+      const workspace = get().workspace;
+      if (!workspace) return;
+      try {
+        await bridge.gitDiscard(workspace.path, relPath);
+        await get().loadGitStatus();
+      } catch (err) {
+        set({ gitError: err instanceof Error ? err.message : String(err) });
+      }
+    },
+
+    commitChanges: async (message: string) => {
+      const workspace = get().workspace;
+      if (!workspace) return;
+      try {
+        await bridge.gitCommit(workspace.path, message);
+        await get().loadGitStatus();
+      } catch (err) {
+        set({ gitError: err instanceof Error ? err.message : String(err) });
+      }
+    },
+
+    gitPush: async () => {
+      const workspace = get().workspace;
+      if (!workspace) return;
+      set({ gitBusy: true, gitError: null });
+      try {
+        const res = await bridge.gitPush(workspace.path);
+        if (!res.ok) set({ gitError: res.message ?? 'git push failed' });
+        await get().loadGitStatus();
+      } finally {
+        set({ gitBusy: false });
+      }
+    },
+
+    gitPull: async () => {
+      const workspace = get().workspace;
+      if (!workspace) return;
+      set({ gitBusy: true, gitError: null });
+      try {
+        const res = await bridge.gitPull(workspace.path);
+        if (!res.ok) set({ gitError: res.message ?? 'git pull failed' });
+        await get().loadGitStatus();
+      } finally {
+        set({ gitBusy: false });
+      }
     },
   };
 });

--- a/packages/http-core/src/git/index.ts
+++ b/packages/http-core/src/git/index.ts
@@ -1,0 +1,6 @@
+export { parsePorcelainStatus } from './porcelain.js';
+export type {
+  GitFileChange,
+  GitFileChangeStatus,
+  ParsedGitStatus,
+} from './porcelain.js';

--- a/packages/http-core/src/git/porcelain.ts
+++ b/packages/http-core/src/git/porcelain.ts
@@ -1,0 +1,165 @@
+// Pure parser for `git status --porcelain=v1 -b -z` output. Kept here (and
+// not in the desktop main process) so it can be imported and unit-tested
+// without pulling electron into the test runner.
+
+export type GitFileChangeStatus =
+  | 'untracked'
+  | 'modified'
+  | 'deleted'
+  | 'added'
+  | 'renamed';
+
+export interface GitFileChange {
+  path: string;
+  status: GitFileChangeStatus;
+  staged: boolean;
+  // Only set for renames.
+  originalPath?: string;
+}
+
+export interface ParsedGitStatus {
+  branch: string | null;
+  upstream: string | null;
+  ahead: number;
+  behind: number;
+  changes: GitFileChange[];
+}
+
+function mapCode(code: string): GitFileChangeStatus | null {
+  switch (code) {
+    case 'M':
+      return 'modified';
+    case 'A':
+      return 'added';
+    case 'D':
+      return 'deleted';
+    case 'R':
+      return 'renamed';
+    case 'C':
+      return 'added';
+    case 'U':
+      return 'modified';
+    case 'T':
+      return 'modified';
+    case '?':
+      return 'untracked';
+    default:
+      return null;
+  }
+}
+
+// Input is the raw NUL-delimited output of
+// `git status --porcelain=v1 -b -z`. The header lines (before the first
+// entry) use "\n" and the entries themselves are NUL-separated. Renames
+// consume an extra NUL-delimited field for the original path.
+export function parsePorcelainStatus(raw: string): ParsedGitStatus {
+  const result: ParsedGitStatus = {
+    branch: null,
+    upstream: null,
+    ahead: 0,
+    behind: 0,
+    changes: [],
+  };
+
+  if (!raw) return result;
+
+  // Split off header (## ...) which appears before the first NUL.
+  const firstNul = raw.indexOf('\0');
+  const headerBlock = firstNul < 0 ? raw : raw.slice(0, firstNul);
+  const body = firstNul < 0 ? '' : raw.slice(firstNul + 1);
+
+  // The branch header may be followed (still before the first NUL) by
+  // a "\n" terminator when there are no entries yet.
+  const headerLine = headerBlock.split('\n').find((l) => l.startsWith('## '));
+  if (headerLine) {
+    const rest = headerLine.slice(3);
+    // Shapes:
+    //   "## HEAD (no branch)"
+    //   "## main"
+    //   "## main...origin/main"
+    //   "## main...origin/main [ahead 1]"
+    //   "## main...origin/main [ahead 1, behind 2]"
+    //   "## No commits yet on main"
+    if (rest.startsWith('No commits yet on ')) {
+      result.branch = rest.slice('No commits yet on '.length).trim();
+    } else if (rest.startsWith('HEAD (no branch)')) {
+      result.branch = null;
+    } else {
+      const bracketIdx = rest.indexOf(' [');
+      const tracking = bracketIdx >= 0 ? rest.slice(0, bracketIdx) : rest;
+      const sep = tracking.indexOf('...');
+      if (sep >= 0) {
+        result.branch = tracking.slice(0, sep);
+        result.upstream = tracking.slice(sep + 3);
+      } else {
+        result.branch = tracking;
+      }
+      if (bracketIdx >= 0) {
+        const inside = rest.slice(bracketIdx + 2, rest.length - 1);
+        for (const part of inside.split(', ')) {
+          const [name, value] = part.split(' ');
+          const n = Number(value);
+          if (name === 'ahead' && Number.isFinite(n)) result.ahead = n;
+          if (name === 'behind' && Number.isFinite(n)) result.behind = n;
+        }
+      }
+    }
+  }
+
+  if (!body) return result;
+
+  // Walk NUL-separated entries. Rename entries consume an extra field.
+  const fields = body.split('\0');
+  // `split` leaves a trailing empty field after the final NUL — drop it.
+  if (fields.length > 0 && fields[fields.length - 1] === '') fields.pop();
+
+  for (let i = 0; i < fields.length; i++) {
+    const entry = fields[i]!;
+    if (entry.length < 3) continue;
+    const xy = entry.slice(0, 2);
+    const path = entry.slice(3);
+    const x = xy[0]!;
+    const y = xy[1]!;
+
+    if (x === '?' && y === '?') {
+      result.changes.push({ path, status: 'untracked', staged: false });
+      continue;
+    }
+
+    // Renames: original path follows in the next field.
+    if (x === 'R' || y === 'R') {
+      const originalPath = fields[i + 1] ?? '';
+      i += 1;
+      if (x === 'R') {
+        result.changes.push({
+          path,
+          status: 'renamed',
+          staged: true,
+          originalPath,
+        });
+      }
+      if (y === 'R') {
+        result.changes.push({
+          path,
+          status: 'renamed',
+          staged: false,
+          originalPath,
+        });
+      }
+      continue;
+    }
+
+    // Staged change (index column).
+    if (x !== ' ' && x !== '?') {
+      const status = mapCode(x);
+      if (status) result.changes.push({ path, status, staged: true });
+    }
+    // Unstaged change (worktree column).
+    if (y !== ' ' && y !== '?') {
+      const status = mapCode(y);
+      if (status) result.changes.push({ path, status, staged: false });
+    }
+  }
+
+  return result;
+}

--- a/packages/http-core/src/index.ts
+++ b/packages/http-core/src/index.ts
@@ -18,5 +18,6 @@ export * from './scrapeDo/index.js';
 export * from './cookies/index.js';
 export * from './load/index.js';
 export * from './auto-headers.js';
+export * from './git/index.js';
 
 export type { ScrapemanRequest, ExecutedResponse };

--- a/packages/http-core/tests/gitPorcelain.test.ts
+++ b/packages/http-core/tests/gitPorcelain.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { parsePorcelainStatus } from '../src/git/porcelain.js';
+
+// Helper: build a porcelain -z blob from an array of entries. The real
+// git output has the branch header followed by a NUL, then each entry
+// terminated by NUL. Renames carry an extra NUL-delimited original path.
+function build(header: string, entries: string[]): string {
+  return header + '\0' + entries.join('\0') + (entries.length ? '\0' : '');
+}
+
+describe('parsePorcelainStatus', () => {
+  it('returns empty state for empty input', () => {
+    const out = parsePorcelainStatus('');
+    expect(out.branch).toBeNull();
+    expect(out.changes).toEqual([]);
+    expect(out.ahead).toBe(0);
+    expect(out.behind).toBe(0);
+  });
+
+  it('parses branch name without upstream', () => {
+    const out = parsePorcelainStatus(build('## main', []));
+    expect(out.branch).toBe('main');
+    expect(out.upstream).toBeNull();
+  });
+
+  it('parses branch name and upstream with ahead/behind', () => {
+    const out = parsePorcelainStatus(
+      build('## feat/x...origin/feat/x [ahead 2, behind 3]', []),
+    );
+    expect(out.branch).toBe('feat/x');
+    expect(out.upstream).toBe('origin/feat/x');
+    expect(out.ahead).toBe(2);
+    expect(out.behind).toBe(3);
+  });
+
+  it('parses "No commits yet" state', () => {
+    const out = parsePorcelainStatus(build('## No commits yet on main', []));
+    expect(out.branch).toBe('main');
+  });
+
+  it('parses modified, staged, deleted, untracked', () => {
+    const out = parsePorcelainStatus(
+      build('## main', [
+        ' M src/a.ts',
+        'M  src/b.ts',
+        ' D src/c.ts',
+        '?? src/d.ts',
+        'A  src/e.ts',
+      ]),
+    );
+    expect(out.changes).toEqual([
+      { path: 'src/a.ts', status: 'modified', staged: false },
+      { path: 'src/b.ts', status: 'modified', staged: true },
+      { path: 'src/c.ts', status: 'deleted', staged: false },
+      { path: 'src/d.ts', status: 'untracked', staged: false },
+      { path: 'src/e.ts', status: 'added', staged: true },
+    ]);
+  });
+
+  it('parses renames with original path in next field', () => {
+    const out = parsePorcelainStatus(
+      build('## main', ['R  new/path.ts', 'old/path.ts']),
+    );
+    expect(out.changes).toHaveLength(1);
+    expect(out.changes[0]).toEqual({
+      path: 'new/path.ts',
+      status: 'renamed',
+      staged: true,
+      originalPath: 'old/path.ts',
+    });
+  });
+
+  it('emits two change rows for files that are both staged and dirty', () => {
+    const out = parsePorcelainStatus(build('## main', ['MM src/a.ts']));
+    expect(out.changes).toEqual([
+      { path: 'src/a.ts', status: 'modified', staged: true },
+      { path: 'src/a.ts', status: 'modified', staged: false },
+    ]);
+  });
+
+  it('handles detached HEAD header', () => {
+    const out = parsePorcelainStatus(build('## HEAD (no branch)', []));
+    expect(out.branch).toBeNull();
+  });
+});

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -300,6 +300,33 @@ export type ImportCurlResult =
 
 export type CodegenTarget = 'curl' | 'fetch' | 'python' | 'go';
 
+export type GitFileChangeStatus =
+  | 'untracked'
+  | 'modified'
+  | 'deleted'
+  | 'added'
+  | 'renamed';
+
+export interface GitFileChange {
+  path: string;
+  status: GitFileChangeStatus;
+  staged: boolean;
+  originalPath?: string;
+}
+
+export interface GitStatus {
+  isRepo: boolean;
+  branch: string | null;
+  ahead: number;
+  behind: number;
+  changes: GitFileChange[];
+}
+
+export interface GitOpResult {
+  ok: boolean;
+  message?: string;
+}
+
 export interface CodegenInput {
   target: CodegenTarget;
   request: ScrapemanRequest;
@@ -395,4 +422,18 @@ export interface ScrapemanBridge {
   envSetActive: (workspacePath: string, name: string | null) => Promise<void>;
 
   onWorkspaceEvent: (handler: (event: WorkspaceEvent) => void) => () => void;
+
+  // Git
+  gitStatus: (workspacePath: string) => Promise<GitStatus>;
+  gitDiff: (
+    workspacePath: string,
+    relPath: string,
+    options: { staged: boolean },
+  ) => Promise<string>;
+  gitStage: (workspacePath: string, relPath: string) => Promise<void>;
+  gitUnstage: (workspacePath: string, relPath: string) => Promise<void>;
+  gitDiscard: (workspacePath: string, relPath: string) => Promise<void>;
+  gitCommit: (workspacePath: string, message: string) => Promise<void>;
+  gitPush: (workspacePath: string) => Promise<GitOpResult>;
+  gitPull: (workspacePath: string) => Promise<GitOpResult>;
 }


### PR DESCRIPTION
Kapatır #18.

Workspace bir git reposu olduğunda VS Code tarzı kaynak kontrol panelini çalıştırır. Yeni runtime bağımlılığı yok — tüm git çağrıları `child_process.execFile` ile array-arg olarak yapılır, shell'den geçmez.

## Ana eklemeler

- **Yeni IPC kanalları** (`git:status`, `git:diff`, `git:stage`, `git:unstage`, `git:discard`, `git:commit`, `git:push`, `git:pull`) — main + preload + `ScrapemanBridge` tipleri.
- **Porcelain parser** `@scrapeman/http-core/src/git/porcelain.ts` içinde saf fonksiyon olarak; electron olmadan test edilebilir. 8 yeni vitest case (branch, ahead/behind, rename, untracked, staged+dirty, detached HEAD).
- **SourceControlPanel** — staged/unstaged listeler, per-row stage/unstage/discard, commit textarea + buton, push/pull (ahead/behind göstergeli, işlem sırasında disabled), refresh, inline diff viewer (+/- renklendirme).
- **Sidebar** Files/Git tab switcher'ı + dirty badge; file tree'de M/A/D/U/R rozetleri.
- **Store slice** `gitStatus` + tüm aksiyonlar; `saveActive` sonrası otomatik refresh.
- `git:discard` için renderer tarafında confirm dialog.

## Kapsam dışı (V2)

- Hunk / satır bazlı staging
- Merge conflict UI
- Branch switch / create / history view
- Stash, rebase, cherry-pick
- Credential prompting (kullanıcının git credential helper'ına güveniyoruz)
- Workspace git repo değilse `git init` + remote ekleme akışı (issue'daki Mod B)

## Doğrulama

- `pnpm -r typecheck` temiz
- `pnpm -r test` — 145 / 145 (yeni 8 parser testi dahil)
- `pnpm --filter=@scrapeman/desktop build` başarılı
