### PR TITLE
fix(git): unstick the Source Control panel loading state

### DIFF
--- a/apps/desktop/src/renderer/src/components/SourceControlPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/SourceControlPanel.tsx
@@ -28,6 +28,7 @@ interface SelectedFile {
 export function SourceControlPanel(): JSX.Element {
   const workspace = useAppStore((s) => s.workspace);
   const gitStatus = useAppStore((s) => s.gitStatus);
+  const gitLoaded = useAppStore((s) => s.gitLoaded);
   const gitError = useAppStore((s) => s.gitError);
   const gitBusy = useAppStore((s) => s.gitBusy);
   const loadGitStatus = useAppStore((s) => s.loadGitStatus);
@@ -84,10 +85,29 @@ export function SourceControlPanel(): JSX.Element {
     );
   }
 
-  if (!gitStatus) {
+  if (!gitLoaded) {
     return (
       <div className="flex h-full items-center justify-center px-6 text-center text-xs text-ink-3">
         Loading git status…
+      </div>
+    );
+  }
+
+  if (!gitStatus) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center">
+        <div className="text-sm font-semibold text-ink-1">
+          Git status unavailable
+        </div>
+        <div className="text-xs text-method-delete">
+          {gitError ?? 'Unknown error'}
+        </div>
+        <button
+          onClick={() => void loadGitStatus()}
+          className="btn-ghost text-accent hover:text-accent-hover"
+        >
+          Retry
+        </button>
       </div>
     );
   }

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -184,6 +184,7 @@ interface AppState {
 
   // Git
   gitStatus: GitStatus | null;
+  gitLoaded: boolean;
   gitError: string | null;
   gitBusy: boolean;
   loadGitStatus: () => Promise<void>;
@@ -475,6 +476,7 @@ export const useAppStore = create<AppState>((set, get) => {
     tabs: [],
     activeTabId: null,
     gitStatus: null,
+    gitLoaded: false,
     gitError: null,
     gitBusy: false,
     saveDialogOpen: false,
@@ -503,6 +505,7 @@ export const useAppStore = create<AppState>((set, get) => {
         activeEnvironment: null,
         history: [],
         gitStatus: null,
+        gitLoaded: false,
         gitError: null,
       });
       await get().loadRecents();
@@ -1094,14 +1097,18 @@ export const useAppStore = create<AppState>((set, get) => {
     loadGitStatus: async () => {
       const workspace = get().workspace;
       if (!workspace) {
-        set({ gitStatus: null });
+        set({ gitStatus: null, gitLoaded: false, gitError: null });
         return;
       }
       try {
         const status = await bridge.gitStatus(workspace.path);
-        set({ gitStatus: status, gitError: null });
+        set({ gitStatus: status, gitError: null, gitLoaded: true });
       } catch (err) {
-        set({ gitError: err instanceof Error ? err.message : String(err) });
+        set({
+          gitStatus: null,
+          gitError: err instanceof Error ? err.message : String(err),
+          gitLoaded: true,
+        });
       }
     },
 


### PR DESCRIPTION
## Sorun
Source Control sekmesi "Loading git status…" ekraninda takili kaliyordu.

## Kok neden
`loadGitStatus` hata durumunda `gitStatus`'u `null` olarak birakiyor, `SourceControlPanel` de `gitStatus === null` oldugunda kosulsuz "Loading…" render ediyordu. `git` PATH'te yoksa veya `execFile` herhangi bir sebeple reddederse UI sonsuza kadar yukleniyor gorunuyor, `gitError` de hicbir zaman ekrana cikmiyordu.

## Cozum
- Store'a `gitLoaded: boolean` bayragi eklendi; `loadGitStatus` hem basari hem hata yollarinda `gitLoaded: true` set ediyor.
- Panel artik "loading" icin `!gitLoaded`'i kullaniyor; yuklendi ama `gitStatus` yoksa hata mesaji + Retry butonu gosteriyor.
- Workspace acildiginda `gitLoaded` sifirlaniyor.

Dokunulan dosyalar:
- `apps/desktop/src/renderer/src/store.ts`
- `apps/desktop/src/renderer/src/components/SourceControlPanel.tsx`

## Dogrulama
- `pnpm -r typecheck` temiz
- `pnpm -r test` 145/145
- `pnpm --filter=@scrapeman/desktop build` basarili