### PR TITLE
fix(sidebar): drag requests into folders + create new requests inside folders

### DIFF
--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CollectionNode, GitFileChangeStatus } from '@scrapeman/shared-types';
 import { useAppStore } from '../store.js';
 import {
@@ -56,10 +56,12 @@ export function Sidebar(): JSX.Element {
   const createFolder = useAppStore((s) => s.createFolder);
   const renameNode = useAppStore((s) => s.renameNode);
   const deleteNode = useAppStore((s) => s.deleteNode);
+  const moveNode = useAppStore((s) => s.moveNode);
   const gitStatus = useAppStore((s) => s.gitStatus);
 
   const [dialog, setDialog] = useState<DialogState>({ kind: 'none' });
   const [view, setView] = useState<SidebarView>('files');
+  const [selectedFolder, setSelectedFolder] = useState<string>('');
 
   const gitStatusByPath = useMemo(() => {
     const map = new Map<string, GitFileChangeStatus>();
@@ -135,12 +137,21 @@ export function Sidebar(): JSX.Element {
       ) : (
         <FilesView
           workspaceName={workspace.name}
-          onNewRequest={() => setDialog({ kind: 'newRequest', parent: '' })}
-          onNewFolder={() => setDialog({ kind: 'newFolder', parent: '' })}
+          onNewRequest={() =>
+            setDialog({ kind: 'newRequest', parent: selectedFolder })
+          }
+          onNewFolder={() =>
+            setDialog({ kind: 'newFolder', parent: selectedFolder })
+          }
           onPick={() => void pickAndOpenWorkspace()}
           root={root}
           gitStatusByPath={gitStatusByPath}
           setDialog={setDialog}
+          selectedFolder={selectedFolder}
+          onSelectFolder={setSelectedFolder}
+          onMoveRequest={(relPath, parent) =>
+            void moveNode(relPath, parent)
+          }
         />
       )}
 
@@ -202,6 +213,9 @@ interface FilesViewProps {
   root: NonNullable<ReturnType<typeof useAppStore.getState>['root']>;
   gitStatusByPath: Map<string, GitFileChangeStatus>;
   setDialog: (dialog: DialogState) => void;
+  selectedFolder: string;
+  onSelectFolder: (relPath: string) => void;
+  onMoveRequest: (relPath: string, newParent: string) => void;
 }
 
 function FilesView({
@@ -212,7 +226,15 @@ function FilesView({
   root,
   gitStatusByPath,
   setDialog,
+  selectedFolder,
+  onSelectFolder,
+  onMoveRequest,
 }: FilesViewProps): JSX.Element {
+  const [expandTick, setExpandTick] = useState<{ path: string; tick: number } | null>(
+    null,
+  );
+  const expandFolder = (relPath: string): void =>
+    setExpandTick({ path: relPath, tick: Date.now() });
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex h-10 items-center gap-1 border-b border-line px-2">
@@ -237,7 +259,26 @@ function FilesView({
           maxSize={85}
           storageKey="sidebar/history"
           first={
-            <div className="h-full overflow-auto py-1">
+            <div
+              className="h-full overflow-auto py-1"
+              onClick={(e) => {
+                if (e.target === e.currentTarget) onSelectFolder('');
+              }}
+              onDragOver={(e) => {
+                if (e.dataTransfer.types.includes('application/x-scrapeman-req')) {
+                  e.preventDefault();
+                  e.dataTransfer.dropEffect = 'move';
+                }
+              }}
+              onDrop={(e) => {
+                const relPath = e.dataTransfer.getData(
+                  'application/x-scrapeman-req',
+                );
+                if (!relPath) return;
+                e.preventDefault();
+                onMoveRequest(relPath, '');
+              }}
+            >
               {root.children.length === 0 ? (
                 <div className="flex flex-col items-center justify-center gap-2 px-6 py-12 text-center">
                   <div className="text-xs text-ink-3">This workspace is empty.</div>
@@ -255,6 +296,11 @@ function FilesView({
                     node={child}
                     depth={0}
                     gitStatusByPath={gitStatusByPath}
+                    selectedFolder={selectedFolder}
+                    onSelectFolder={onSelectFolder}
+                    onMoveRequest={onMoveRequest}
+                    expandSignal={expandTick}
+                    onRequestExpand={expandFolder}
                     onNewRequest={(parent) => setDialog({ kind: 'newRequest', parent })}
                     onNewFolder={(parent) => setDialog({ kind: 'newFolder', parent })}
                     onRename={(relPath, currentName) =>
@@ -279,6 +325,11 @@ interface TreeNodeProps {
   node: CollectionNode;
   depth: number;
   gitStatusByPath: Map<string, GitFileChangeStatus>;
+  selectedFolder: string;
+  onSelectFolder: (relPath: string) => void;
+  onMoveRequest: (relPath: string, newParent: string) => void;
+  expandSignal: { path: string; tick: number } | null;
+  onRequestExpand: (relPath: string) => void;
   onNewRequest: (parent: string) => void;
   onNewFolder: (parent: string) => void;
   onRename: (relPath: string, currentName: string) => void;
@@ -289,12 +340,29 @@ function TreeNode({
   node,
   depth,
   gitStatusByPath,
+  selectedFolder,
+  onSelectFolder,
+  onMoveRequest,
+  expandSignal,
+  onRequestExpand,
   onNewRequest,
   onNewFolder,
   onRename,
   onDelete,
 }: TreeNodeProps): JSX.Element {
   const [expanded, setExpanded] = useState(depth < 1);
+  const [dragOver, setDragOver] = useState(false);
+
+  useEffect(() => {
+    if (
+      node.kind === 'folder' &&
+      expandSignal &&
+      expandSignal.path === node.relPath
+    ) {
+      setExpanded(true);
+    }
+  }, [expandSignal, node]);
+
   const tabs = useAppStore((s) => s.tabs);
   const activeTabId = useAppStore((s) => s.activeTabId);
   const openRequest = useAppStore((s) => s.openRequest);
@@ -308,14 +376,46 @@ function TreeNode({
   const indent = 10 + depth * 14;
 
   if (node.kind === 'folder') {
+    const selected = selectedFolder === node.relPath;
     return (
       <div>
         <ContextMenu>
           <ContextMenuTrigger asChild>
             <button
-              onClick={() => setExpanded(!expanded)}
+              onClick={() => {
+                setExpanded(!expanded);
+                onSelectFolder(node.relPath);
+              }}
+              onContextMenu={() => onSelectFolder(node.relPath)}
+              onDragOver={(e) => {
+                if (
+                  e.dataTransfer.types.includes('application/x-scrapeman-req')
+                ) {
+                  e.preventDefault();
+                  e.dataTransfer.dropEffect = 'move';
+                  if (!dragOver) setDragOver(true);
+                }
+              }}
+              onDragLeave={() => setDragOver(false)}
+              onDrop={(e) => {
+                setDragOver(false);
+                const relPath = e.dataTransfer.getData(
+                  'application/x-scrapeman-req',
+                );
+                if (!relPath || relPath === node.relPath) return;
+                e.preventDefault();
+                e.stopPropagation();
+                onMoveRequest(relPath, node.relPath);
+                onRequestExpand(node.relPath);
+              }}
               style={{ paddingLeft: `${indent}px` }}
-              className="group relative flex h-7 w-full items-center gap-1.5 pr-3 text-left text-xs text-ink-2 hover:bg-bg-hover"
+              className={`group relative flex h-7 w-full items-center gap-1.5 pr-3 text-left text-xs text-ink-2 ${
+                dragOver
+                  ? 'bg-accent-soft ring-1 ring-inset ring-accent'
+                  : selected
+                    ? 'bg-bg-hover'
+                    : 'hover:bg-bg-hover'
+              }`}
             >
               <span className="w-3 text-center text-[9px] text-ink-4">
                 {expanded ? '▾' : '▸'}
@@ -349,6 +449,11 @@ function TreeNode({
               node={child}
               depth={depth + 1}
               gitStatusByPath={gitStatusByPath}
+              selectedFolder={selectedFolder}
+              onSelectFolder={onSelectFolder}
+              onMoveRequest={onMoveRequest}
+              expandSignal={expandSignal}
+              onRequestExpand={onRequestExpand}
               onNewRequest={onNewRequest}
               onNewFolder={onNewFolder}
               onRename={onRename}
@@ -363,6 +468,16 @@ function TreeNode({
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <button
+          draggable
+          onDragStart={(e) => {
+            e.dataTransfer.effectAllowed = 'move';
+            e.dataTransfer.setData(
+              'application/x-scrapeman-req',
+              node.relPath,
+            );
+            // Some browsers require text/plain for a drag to start reliably.
+            e.dataTransfer.setData('text/plain', node.relPath);
+          }}
           onClick={() => void openRequest(node.relPath)}
           style={{ paddingLeft: `${indent + 16}px` }}
           className={`group relative flex h-7 w-full items-center gap-2 pr-3 text-left text-xs ${

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -181,6 +181,7 @@ interface AppState {
   createFolder: (parentRelPath: string, name: string) => Promise<void>;
   renameNode: (relPath: string, newName: string) => Promise<void>;
   deleteNode: (relPath: string) => Promise<void>;
+  moveNode: (relPath: string, newParentRelPath: string) => Promise<string | null>;
 
   // Git
   gitStatus: GitStatus | null;
@@ -925,6 +926,40 @@ export const useAppStore = create<AppState>((set, get) => {
       if (!workspace) return;
       await bridge.workspaceRename(workspace.path, relPath, newName);
       await get().refreshTree();
+    },
+
+    moveNode: async (relPath: string, newParentRelPath: string) => {
+      const workspace = get().workspace;
+      if (!workspace) return null;
+      const oldParent = relPath.includes('/')
+        ? relPath.slice(0, relPath.lastIndexOf('/'))
+        : '';
+      if (oldParent === newParentRelPath) return null;
+      try {
+        const newRelPath = await bridge.workspaceMove(
+          workspace.path,
+          relPath,
+          newParentRelPath,
+        );
+        // Update any open tab pointing at the moved file.
+        const oldId = `file:${relPath}`;
+        const newId = `file:${newRelPath}`;
+        const tabs = get().tabs;
+        if (tabs.some((t) => t.id === oldId)) {
+          set({
+            tabs: tabs.map((t) =>
+              t.id === oldId ? { ...t, id: newId, relPath: newRelPath } : t,
+            ),
+            activeTabId: get().activeTabId === oldId ? newId : get().activeTabId,
+          });
+        }
+        await get().refreshTree();
+        return newRelPath;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        window.alert(`Could not move: ${message}`);
+        return null;
+      }
     },
 
     deleteNode: async (relPath: string) => {

--- a/packages/http-core/src/workspace/fs.ts
+++ b/packages/http-core/src/workspace/fs.ts
@@ -1,5 +1,5 @@
 import { promises as fsp } from 'node:fs';
-import { basename, dirname, join, posix, relative, resolve, sep } from 'node:path';
+import { basename, dirname, isAbsolute, join, posix, relative, resolve, sep } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { FORMAT_VERSION } from '@scrapeman/shared-types';
 import type {
@@ -108,9 +108,67 @@ export class WorkspaceFs {
   async move(relPath: string, newParentRelPath: string): Promise<string> {
     const absOld = this.resolveSafe(relPath);
     const absNewParent = this.resolveSafe(newParentRelPath);
+    if (absOld === absNewParent) {
+      return this.toRel(absOld);
+    }
+    const oldParent = dirname(absOld);
+    if (oldParent === absNewParent) {
+      return this.toRel(absOld);
+    }
+    // Prevent moving a folder into itself or its descendants.
+    const stat = await fsp.stat(absOld);
+    if (stat.isDirectory()) {
+      const rel = relative(absOld, absNewParent);
+      if (rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))) {
+        throw new Error('cannot move a folder into itself');
+      }
+    }
     await fsp.mkdir(absNewParent, { recursive: true });
     const absNew = join(absNewParent, basename(absOld));
+    try {
+      await fsp.access(absNew);
+      throw new Error(`destination already exists: ${basename(absOld)}`);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    }
+
+    // If we're moving a request file, relocate its referenced sidecars too.
+    const sidecarMoves: Array<{ from: string; to: string }> = [];
+    if (stat.isFile() && absOld.endsWith(REQUEST_EXT)) {
+      const text = await fsp.readFile(absOld, 'utf8');
+      for (const ref of extractFileRefs(text)) {
+        if (isAbsolute(ref)) continue;
+        const fromAbs = resolve(oldParent, ref);
+        try {
+          this.assertInsideRoot(fromAbs);
+        } catch {
+          continue;
+        }
+        try {
+          await fsp.access(fromAbs);
+        } catch {
+          continue;
+        }
+        const toAbs = resolve(absNewParent, ref);
+        this.assertInsideRoot(toAbs);
+        sidecarMoves.push({ from: fromAbs, to: toAbs });
+      }
+    }
+
+    for (const { to } of sidecarMoves) {
+      try {
+        await fsp.access(to);
+        throw new Error(`sidecar destination already exists: ${to}`);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+    }
+
     await fsp.rename(absOld, absNew);
+    for (const { from, to } of sidecarMoves) {
+      await fsp.mkdir(dirname(to), { recursive: true });
+      await fsp.rename(from, to);
+    }
     return this.toRel(absNew);
   }
 
@@ -215,6 +273,25 @@ function slugify(name: string): string {
 
 function stableId(relPath: string): string {
   return `n_${Buffer.from(relPath).toString('base64url')}`;
+}
+
+function extractFileRefs(yamlText: string): string[] {
+  // Grab every `file: <value>` line. Sidecar-backed bodies (json/xml/text/html/js),
+  // binary bodies, and multipart file parts all serialize this way.
+  const refs: string[] = [];
+  const re = /^\s*file:\s*(.+?)\s*$/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(yamlText)) !== null) {
+    let value = m[1]!;
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (value) refs.push(value);
+  }
+  return refs;
 }
 
 function posixRelative(from: string, to: string): string {

--- a/packages/http-core/tests/workspace.test.ts
+++ b/packages/http-core/tests/workspace.test.ts
@@ -113,4 +113,27 @@ describe('WorkspaceFs', () => {
     const movedPath = await fs.move(requestPath, folderPath);
     expect(movedPath.startsWith(folderPath)).toBe(true);
   });
+
+  it('moves a sidecar body alongside its request', async () => {
+    const requestPath = await fs.createRequest('', 'BigMover');
+    const req = makeRequest('BigMover');
+    req.body = { type: 'json', content: 'x'.repeat(5000) };
+    await fs.writeRequest(requestPath, req);
+
+    const folderPath = await fs.createFolder('', 'Dest');
+    const movedPath = await fs.move(requestPath, folderPath);
+
+    const readBack = await fs.readRequest(movedPath);
+    expect(readBack.body).toMatchObject({
+      type: 'json',
+      content: 'x'.repeat(5000),
+    });
+  });
+
+  it('refuses to move when destination already has a same-named file', async () => {
+    const requestA = await fs.createRequest('', 'Dup');
+    const folder = await fs.createFolder('', 'Bucket');
+    await fs.createRequest(folder, 'Dup');
+    await expect(fs.move(requestA, folder)).rejects.toThrow(/already exists/);
+  });
 });


### PR DESCRIPTION
## Özet

Sidebar workspace ağacında iki kullanılabilirlik hatası düzeltildi:

- **Request'i klasöre sürükle-bırak**: Request satırları artık `draggable`, klasör satırları da drop-target. Bırakıldığında request (ve varsa `files/<slug>.body.<ext>` sidecar dosyası) yeni klasörün içine taşınır. Drop sırasında klasör otomatik açılır.
- **Klasör içine yeni request**: Toolbar `+` butonu artık "seçili" klasörü parent olarak kullanır (klasöre tıklayınca/sağ-tık yapınca seçili olur). Boş alana tıklamak seçimi sıfırlar. Klasör sağ-tık menüsündeki "New request / New folder" seçenekleri hâlâ çalışıyor.

## Değişenler

- `packages/http-core/src/workspace/fs.ts` — `move()` artık request YAML'ındaki `file:` referanslarını tarıyor, aynı klasördeki sidecar dosyalarını birlikte taşıyor. Hedefte aynı isimli dosya varsa hata atıyor.
- `apps/desktop/src/renderer/src/store.ts` — yeni `moveNode` action; açık bir tab taşınan dosyayı işaret ediyorsa id/relPath güncelleniyor.
- `apps/desktop/src/renderer/src/components/Sidebar.tsx` — HTML5 DnD (TabBar ile aynı desen), `selectedFolder` state, drop highlight, auto-expand.
- `packages/http-core/tests/workspace.test.ts` — sidecar move ve duplicate-target testleri.

## Test plan

- [x] `pnpm -r typecheck`
- [x] `pnpm -r test` — 147 passed (önceki 145 + 2 yeni)
- [x] `pnpm --filter=@scrapeman/desktop build`
- [ ] Manuel: request'i klasöre sürükle, klasöre tıklayıp toolbar `+` ile request oluştur