### PR TITLE
feat(git): stage-all/unstage-all + bottom status bar

### DIFF
--- a/apps/desktop/src/main/git.ts
+++ b/apps/desktop/src/main/git.ts
@@ -136,6 +136,14 @@ export async function gitUnstage(
   }
 }
 
+export async function gitStageAll(workspacePath: string): Promise<void> {
+  await run(workspacePath, ['add', '-A']);
+}
+
+export async function gitUnstageAll(workspacePath: string): Promise<void> {
+  await run(workspacePath, ['reset']);
+}
+
 export async function gitDiscard(
   workspacePath: string,
   relPath: string,

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -35,7 +35,9 @@ import {
   gitStatus,
   gitDiff,
   gitStage,
+  gitStageAll,
   gitUnstage,
+  gitUnstageAll,
   gitDiscard,
   gitCommit,
   gitPush,
@@ -568,6 +570,20 @@ app.whenReady().then(() => {
       }
     },
   );
+  ipcMain.handle('git:stageAll', async (_e, workspacePath: string) => {
+    try {
+      await gitStageAll(workspacePath);
+    } catch (err) {
+      throw toGitError(err);
+    }
+  });
+  ipcMain.handle('git:unstageAll', async (_e, workspacePath: string) => {
+    try {
+      await gitUnstageAll(workspacePath);
+    } catch (err) {
+      throw toGitError(err);
+    }
+  });
   ipcMain.handle(
     'git:unstage',
     async (_e, workspacePath: string, relPath: string) => {

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -183,8 +183,12 @@ const api: ScrapemanBridge = {
     ) as Promise<string>,
   gitStage: (workspacePath: string, relPath: string) =>
     ipcRenderer.invoke('git:stage', workspacePath, relPath) as Promise<void>,
+  gitStageAll: (workspacePath: string) =>
+    ipcRenderer.invoke('git:stageAll', workspacePath) as Promise<void>,
   gitUnstage: (workspacePath: string, relPath: string) =>
     ipcRenderer.invoke('git:unstage', workspacePath, relPath) as Promise<void>,
+  gitUnstageAll: (workspacePath: string) =>
+    ipcRenderer.invoke('git:unstageAll', workspacePath) as Promise<void>,
   gitDiscard: (workspacePath: string, relPath: string) =>
     ipcRenderer.invoke('git:discard', workspacePath, relPath) as Promise<void>,
   gitCommit: (workspacePath: string, message: string) =>

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -9,6 +9,7 @@ import { EnvironmentMenu } from './components/EnvironmentMenu.js';
 import { CookiesPanel } from './components/CookiesPanel.js';
 import { SettingsDialog } from './components/SettingsDialog.js';
 import { SplitPane, type SplitOrientation } from './components/SplitPane.js';
+import { GitStatusBar } from './components/GitStatusBar.js';
 import { useAppStore } from './store.js';
 import { bridge } from './bridge.js';
 import { usePlatform } from './hooks/usePlatform.js';
@@ -196,7 +197,7 @@ export function App(): JSX.Element {
         onClose={() => setPaletteOpen(false)}
         commands={commands}
       />
-      <div className="flex-1 overflow-hidden">
+      <div className="min-h-0 flex-1 overflow-hidden">
         <SplitPane
           orientation="horizontal"
           initialSize={20}
@@ -223,6 +224,7 @@ export function App(): JSX.Element {
           }
         />
       </div>
+      <GitStatusBar />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/src/components/GitStatusBar.tsx
+++ b/apps/desktop/src/renderer/src/components/GitStatusBar.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+import { useAppStore } from '../store.js';
+
+export function GitStatusBar(): JSX.Element | null {
+  const workspace = useAppStore((s) => s.workspace);
+  const gitStatus = useAppStore((s) => s.gitStatus);
+  const setSidebarView = useAppStore((s) => s.setSidebarView);
+
+  const counts = useMemo(() => {
+    if (!gitStatus) return { modified: 0, untracked: 0, staged: 0 };
+    let modified = 0;
+    let untracked = 0;
+    let staged = 0;
+    for (const c of gitStatus.changes) {
+      if (c.staged) staged++;
+      else if (c.status === 'untracked') untracked++;
+      else modified++;
+    }
+    return { modified, untracked, staged };
+  }, [gitStatus]);
+
+  if (!workspace) return null;
+
+  if (!gitStatus || !gitStatus.isRepo) {
+    return (
+      <div className="flex h-[22px] items-center border-t border-line bg-bg-subtle px-3 text-[11px] text-ink-3">
+        <span className="truncate">{workspace.name}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-[22px] items-center gap-3 border-t border-line bg-bg-subtle px-3 text-[11px] text-ink-3">
+      <button
+        onClick={() => setSidebarView('git')}
+        title="Open Source Control"
+        className="flex items-center hover:text-ink-1"
+      >
+        ⎇ {gitStatus.branch ?? '(detached)'}
+      </button>
+      {(gitStatus.ahead > 0 || gitStatus.behind > 0) && (
+        <span className="flex items-center gap-1">
+          <span>↑{gitStatus.ahead}</span>
+          <span>↓{gitStatus.behind}</span>
+        </span>
+      )}
+      {counts.modified > 0 && (
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-method-put" />
+          <span>M {counts.modified}</span>
+        </span>
+      )}
+      {counts.untracked > 0 && (
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-method-patch" />
+          <span>U {counts.untracked}</span>
+        </span>
+      )}
+      {counts.staged > 0 && (
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-1.5 w-1.5 rounded-full bg-method-post" />
+          <span>S {counts.staged}</span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -39,8 +39,6 @@ const GIT_STATUS_COLOR: Record<GitFileChangeStatus, string> = {
   renamed: 'text-method-options',
 };
 
-type SidebarView = 'files' | 'git';
-
 type DialogState =
   | { kind: 'none' }
   | { kind: 'newRequest'; parent: string }
@@ -58,9 +56,10 @@ export function Sidebar(): JSX.Element {
   const deleteNode = useAppStore((s) => s.deleteNode);
   const moveNode = useAppStore((s) => s.moveNode);
   const gitStatus = useAppStore((s) => s.gitStatus);
+  const view = useAppStore((s) => s.sidebarView);
+  const setView = useAppStore((s) => s.setSidebarView);
 
   const [dialog, setDialog] = useState<DialogState>({ kind: 'none' });
-  const [view, setView] = useState<SidebarView>('files');
   const [selectedFolder, setSelectedFolder] = useState<string>('');
 
   const gitStatusByPath = useMemo(() => {

--- a/apps/desktop/src/renderer/src/components/SourceControlPanel.tsx
+++ b/apps/desktop/src/renderer/src/components/SourceControlPanel.tsx
@@ -33,7 +33,9 @@ export function SourceControlPanel(): JSX.Element {
   const gitBusy = useAppStore((s) => s.gitBusy);
   const loadGitStatus = useAppStore((s) => s.loadGitStatus);
   const stageFile = useAppStore((s) => s.stageFile);
+  const stageAll = useAppStore((s) => s.stageAll);
   const unstageFile = useAppStore((s) => s.unstageFile);
+  const unstageAll = useAppStore((s) => s.unstageAll);
   const discardFile = useAppStore((s) => s.discardFile);
   const commitChanges = useAppStore((s) => s.commitChanges);
   const gitPush = useAppStore((s) => s.gitPush);
@@ -202,7 +204,19 @@ export function SourceControlPanel(): JSX.Element {
 
         <div className="min-h-0 flex-1 overflow-auto">
           {staged.length > 0 && (
-            <Section label={`Staged Changes (${staged.length})`}>
+            <Section
+              label={`Staged Changes (${staged.length})`}
+              actions={
+                <button
+                  title="Unstage all"
+                  disabled={staged.length === 0}
+                  onClick={() => void unstageAll()}
+                  className="icon-btn disabled:opacity-40"
+                >
+                  −
+                </button>
+              }
+            >
               {staged.map((c) => (
                 <FileRow
                   key={`s:${c.path}`}
@@ -231,7 +245,19 @@ export function SourceControlPanel(): JSX.Element {
           )}
 
           {unstaged.length > 0 && (
-            <Section label={`Changes (${unstaged.length})`}>
+            <Section
+              label={`Changes (${unstaged.length})`}
+              actions={
+                <button
+                  title="Stage all"
+                  disabled={unstaged.length === 0}
+                  onClick={() => void stageAll()}
+                  className="icon-btn disabled:opacity-40"
+                >
+                  +
+                </button>
+              }
+            >
               {unstaged.map((c) => (
                 <FileRow
                   key={`u:${c.path}`}
@@ -310,15 +336,18 @@ export function SourceControlPanel(): JSX.Element {
 
 function Section({
   label,
+  actions,
   children,
 }: {
   label: string;
+  actions?: React.ReactNode;
   children: React.ReactNode;
 }): JSX.Element {
   return (
     <div>
-      <div className="sticky top-0 z-10 border-b border-line bg-bg-subtle px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-ink-3">
-        {label}
+      <div className="sticky top-0 z-10 flex items-center border-b border-line bg-bg-subtle px-3 py-1 text-[10px] font-semibold uppercase tracking-wide text-ink-3">
+        <span className="flex-1 truncate">{label}</span>
+        {actions && <span className="flex items-center gap-1">{actions}</span>}
       </div>
       <div>{children}</div>
     </div>

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -190,7 +190,11 @@ interface AppState {
   gitBusy: boolean;
   loadGitStatus: () => Promise<void>;
   stageFile: (relPath: string) => Promise<void>;
+  stageAll: () => Promise<void>;
   unstageFile: (relPath: string) => Promise<void>;
+  unstageAll: () => Promise<void>;
+  sidebarView: 'files' | 'git';
+  setSidebarView: (view: 'files' | 'git') => void;
   discardFile: (relPath: string) => Promise<void>;
   commitChanges: (message: string) => Promise<void>;
   gitPush: () => Promise<void>;
@@ -480,6 +484,8 @@ export const useAppStore = create<AppState>((set, get) => {
     gitLoaded: false,
     gitError: null,
     gitBusy: false,
+    sidebarView: 'files',
+    setSidebarView: (view) => set({ sidebarView: view }),
     saveDialogOpen: false,
     focusUrlTick: 0,
     importCurlTick: 0,
@@ -1158,11 +1164,33 @@ export const useAppStore = create<AppState>((set, get) => {
       }
     },
 
+    stageAll: async () => {
+      const workspace = get().workspace;
+      if (!workspace) return;
+      try {
+        await bridge.gitStageAll(workspace.path);
+        await get().loadGitStatus();
+      } catch (err) {
+        set({ gitError: err instanceof Error ? err.message : String(err) });
+      }
+    },
+
     unstageFile: async (relPath: string) => {
       const workspace = get().workspace;
       if (!workspace) return;
       try {
         await bridge.gitUnstage(workspace.path, relPath);
+        await get().loadGitStatus();
+      } catch (err) {
+        set({ gitError: err instanceof Error ? err.message : String(err) });
+      }
+    },
+
+    unstageAll: async () => {
+      const workspace = get().workspace;
+      if (!workspace) return;
+      try {
+        await bridge.gitUnstageAll(workspace.path);
         await get().loadGitStatus();
       } catch (err) {
         set({ gitError: err instanceof Error ? err.message : String(err) });

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -431,7 +431,9 @@ export interface ScrapemanBridge {
     options: { staged: boolean },
   ) => Promise<string>;
   gitStage: (workspacePath: string, relPath: string) => Promise<void>;
+  gitStageAll: (workspacePath: string) => Promise<void>;
   gitUnstage: (workspacePath: string, relPath: string) => Promise<void>;
+  gitUnstageAll: (workspacePath: string) => Promise<void>;
   gitDiscard: (workspacePath: string, relPath: string) => Promise<void>;
   gitCommit: (workspacePath: string, message: string) => Promise<void>;
   gitPush: (workspacePath: string) => Promise<GitOpResult>;


### PR DESCRIPTION
## Ozet

Git entegrasyonuna iki kucuk iyilestirme.

### 1. Toplu stage / unstage
- Source Control panelindeki **Changes** basligi yanina `+` (Stage all) butonu eklendi; yeni `git:stageAll` IPC kanali `git add -A` calistiriyor.
- **Staged Changes** basligi yanina `-` (Unstage all) butonu eklendi; `git:unstageAll` kanali `git reset` calistiriyor.
- Butonlar ilgili bolum bosken disabled.

### 2. Alt git status bar
- Pencerenin alt kismina 22px yukseklikte yeni bir status bar eklendi (`GitStatusBar.tsx`).
- Branch adi (tiklanabilir, sidebar'i Git sekmesine geciriyor), ahead/behind, `M` / `U` / `S` sayaclari gosteriliyor.
- Ayri bir polling yok — mevcut `gitStatus` store slice'indan okuyor.
- Workspace yoksa gizli; git repo degilse sadece workspace adini muted renkle gosteriyor.

## Test
- [x] `pnpm -r typecheck`
- [x] `pnpm -r test` (147 passed)
- [x] `pnpm --filter=@scrapeman/desktop build`