### PR TITLE
feat(tabs): right-click context menu with bulk close + dirty guard

### DIFF
--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { CollectionNode, GitFileChangeStatus } from '@scrapeman/shared-types';
 import { useAppStore } from '../store.js';
 import {
@@ -58,6 +58,8 @@ export function Sidebar(): JSX.Element {
   const gitStatus = useAppStore((s) => s.gitStatus);
   const view = useAppStore((s) => s.sidebarView);
   const setView = useAppStore((s) => s.setSidebarView);
+  const revealTick = useAppStore((s) => s.revealInSidebarTick);
+  const revealPath = useAppStore((s) => s.revealInSidebarPath);
 
   const [dialog, setDialog] = useState<DialogState>({ kind: 'none' });
   const [selectedFolder, setSelectedFolder] = useState<string>('');
@@ -151,6 +153,8 @@ export function Sidebar(): JSX.Element {
           onMoveRequest={(relPath, parent) =>
             void moveNode(relPath, parent)
           }
+          revealTick={revealTick}
+          revealPath={revealPath}
         />
       )}
 
@@ -215,6 +219,8 @@ interface FilesViewProps {
   selectedFolder: string;
   onSelectFolder: (relPath: string) => void;
   onMoveRequest: (relPath: string, newParent: string) => void;
+  revealTick: number;
+  revealPath: string | null;
 }
 
 function FilesView({
@@ -228,12 +234,26 @@ function FilesView({
   selectedFolder,
   onSelectFolder,
   onMoveRequest,
+  revealTick,
+  revealPath,
 }: FilesViewProps): JSX.Element {
   const [expandTick, setExpandTick] = useState<{ path: string; tick: number } | null>(
     null,
   );
   const expandFolder = (relPath: string): void =>
     setExpandTick({ path: relPath, tick: Date.now() });
+
+  // Reveal-in-sidebar: bump an internal signal when the store tick changes
+  // so descendant TreeNodes can react via useEffect.
+  const [revealSignal, setRevealSignal] = useState<{
+    path: string;
+    tick: number;
+  } | null>(null);
+  useEffect(() => {
+    if (revealTick > 0 && revealPath) {
+      setRevealSignal({ path: revealPath, tick: revealTick });
+    }
+  }, [revealTick, revealPath]);
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex h-10 items-center gap-1 border-b border-line px-2">
@@ -300,6 +320,7 @@ function FilesView({
                     onMoveRequest={onMoveRequest}
                     expandSignal={expandTick}
                     onRequestExpand={expandFolder}
+                    revealSignal={revealSignal}
                     onNewRequest={(parent) => setDialog({ kind: 'newRequest', parent })}
                     onNewFolder={(parent) => setDialog({ kind: 'newFolder', parent })}
                     onRename={(relPath, currentName) =>
@@ -329,6 +350,7 @@ interface TreeNodeProps {
   onMoveRequest: (relPath: string, newParent: string) => void;
   expandSignal: { path: string; tick: number } | null;
   onRequestExpand: (relPath: string) => void;
+  revealSignal: { path: string; tick: number } | null;
   onNewRequest: (parent: string) => void;
   onNewFolder: (parent: string) => void;
   onRename: (relPath: string, currentName: string) => void;
@@ -344,6 +366,7 @@ function TreeNode({
   onMoveRequest,
   expandSignal,
   onRequestExpand,
+  revealSignal,
   onNewRequest,
   onNewFolder,
   onRename,
@@ -351,6 +374,7 @@ function TreeNode({
 }: TreeNodeProps): JSX.Element {
   const [expanded, setExpanded] = useState(depth < 1);
   const [dragOver, setDragOver] = useState(false);
+  const fileRowRef = useRef<HTMLButtonElement | null>(null);
 
   useEffect(() => {
     if (
@@ -361,6 +385,22 @@ function TreeNode({
       setExpanded(true);
     }
   }, [expandSignal, node]);
+
+  // Reveal-in-sidebar: expand this folder if it's an ancestor of the target,
+  // or scroll this file row into view if it's the target.
+  useEffect(() => {
+    if (!revealSignal) return;
+    if (node.kind === 'folder') {
+      if (
+        node.relPath !== '' &&
+        revealSignal.path.startsWith(`${node.relPath}/`)
+      ) {
+        setExpanded(true);
+      }
+    } else if (node.relPath === revealSignal.path) {
+      fileRowRef.current?.scrollIntoView({ block: 'nearest' });
+    }
+  }, [revealSignal, node]);
 
   const tabs = useAppStore((s) => s.tabs);
   const activeTabId = useAppStore((s) => s.activeTabId);
@@ -453,6 +493,7 @@ function TreeNode({
               onMoveRequest={onMoveRequest}
               expandSignal={expandSignal}
               onRequestExpand={onRequestExpand}
+              revealSignal={revealSignal}
               onNewRequest={onNewRequest}
               onNewFolder={onNewFolder}
               onRename={onRename}
@@ -467,6 +508,7 @@ function TreeNode({
     <ContextMenu>
       <ContextMenuTrigger asChild>
         <button
+          ref={fileRowRef}
           draggable
           onDragStart={(e) => {
             e.dataTransfer.effectAllowed = 'move';

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -243,17 +243,10 @@ function FilesView({
   const expandFolder = (relPath: string): void =>
     setExpandTick({ path: relPath, tick: Date.now() });
 
-  // Reveal-in-sidebar: bump an internal signal when the store tick changes
-  // so descendant TreeNodes can react via useEffect.
-  const [revealSignal, setRevealSignal] = useState<{
-    path: string;
-    tick: number;
-  } | null>(null);
-  useEffect(() => {
-    if (revealTick > 0 && revealPath) {
-      setRevealSignal({ path: revealPath, tick: revealTick });
-    }
-  }, [revealTick, revealPath]);
+  const revealSignal = useMemo<{ path: string; tick: number } | null>(
+    () => (revealTick > 0 && revealPath ? { path: revealPath, tick: revealTick } : null),
+    [revealTick, revealPath],
+  );
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div className="flex h-10 items-center gap-1 border-b border-line px-2">
@@ -387,20 +380,24 @@ function TreeNode({
   }, [expandSignal, node]);
 
   // Reveal-in-sidebar: expand this folder if it's an ancestor of the target,
-  // or scroll this file row into view if it's the target.
+  // or scroll this file row into view if it's the target. Depend on the tick
+  // + this node's relPath rather than the whole node object so unrelated
+  // parent re-renders don't retrigger the scroll.
+  const revealTickValue = revealSignal?.tick ?? 0;
+  const revealTargetPath = revealSignal?.path ?? null;
   useEffect(() => {
-    if (!revealSignal) return;
+    if (!revealTargetPath) return;
     if (node.kind === 'folder') {
       if (
         node.relPath !== '' &&
-        revealSignal.path.startsWith(`${node.relPath}/`)
+        revealTargetPath.startsWith(`${node.relPath}/`)
       ) {
         setExpanded(true);
       }
-    } else if (node.relPath === revealSignal.path) {
+    } else if (node.relPath === revealTargetPath) {
       fileRowRef.current?.scrollIntoView({ block: 'nearest' });
     }
-  }, [revealSignal, node]);
+  }, [revealTickValue, revealTargetPath, node.kind, node.relPath]);
 
   const tabs = useAppStore((s) => s.tabs);
   const activeTabId = useAppStore((s) => s.activeTabId);

--- a/apps/desktop/src/renderer/src/components/TabBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TabBar.tsx
@@ -115,6 +115,9 @@ export function TabBar(): JSX.Element {
         closeAllTabs();
         break;
     }
+    // Clear explicitly so a stale dirtyCount can't flash if the user
+    // reopens the dialog mid-close-animation.
+    setGuard(null);
   };
 
   const guardTitle = ((): string => {

--- a/apps/desktop/src/renderer/src/components/TabBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TabBar.tsx
@@ -1,6 +1,14 @@
-import { useState } from 'react';
+import { forwardRef, useState, type HTMLAttributes } from 'react';
 import { useAppStore, type Tab } from '../store.js';
 import { shortcutLabel } from '../hooks/useShortcuts.js';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from '../ui/ContextMenu.js';
+import { ConfirmDialog } from '../ui/Dialog.js';
 
 const METHOD_COLOR: Record<string, string> = {
   GET: 'text-method-get',
@@ -12,44 +20,211 @@ const METHOD_COLOR: Record<string, string> = {
   OPTIONS: 'text-method-options',
 };
 
+type GuardKind =
+  | 'close'
+  | 'closeOthers'
+  | 'closeRight'
+  | 'closeSaved'
+  | 'closeAll';
+
+interface GuardState {
+  kind: GuardKind;
+  tabId?: string;
+  tabName?: string;
+  dirtyCount: number;
+}
+
 export function TabBar(): JSX.Element {
   const tabs = useAppStore((s) => s.tabs);
   const activeTabId = useAppStore((s) => s.activeTabId);
   const newTab = useAppStore((s) => s.newTab);
   const closeTab = useAppStore((s) => s.closeTab);
+  const closeOtherTabs = useAppStore((s) => s.closeOtherTabs);
+  const closeTabsToRight = useAppStore((s) => s.closeTabsToRight);
+  const closeSavedTabs = useAppStore((s) => s.closeSavedTabs);
+  const closeAllTabs = useAppStore((s) => s.closeAllTabs);
+  const duplicateTab = useAppStore((s) => s.duplicateTab);
+  const revealInSidebar = useAppStore((s) => s.revealInSidebar);
+  const setSidebarView = useAppStore((s) => s.setSidebarView);
   const setActiveTab = useAppStore((s) => s.setActiveTab);
   const reorderTab = useAppStore((s) => s.reorderTab);
 
   const [dragId, setDragId] = useState<string | null>(null);
   const [dropTargetId, setDropTargetId] = useState<string | null>(null);
+  const [guard, setGuard] = useState<GuardState | null>(null);
+
+  const savedCount = tabs.filter((t) => !t.dirty).length;
+
+  const requestClose = (tab: Tab): void => {
+    if (tab.dirty) {
+      setGuard({ kind: 'close', tabId: tab.id, tabName: tab.name, dirtyCount: 1 });
+      return;
+    }
+    closeTab(tab.id);
+  };
+
+  const requestCloseOthers = (tab: Tab): void => {
+    const dirtyCount = tabs.filter((t) => t.id !== tab.id && t.dirty).length;
+    if (dirtyCount > 0) {
+      setGuard({ kind: 'closeOthers', tabId: tab.id, dirtyCount });
+      return;
+    }
+    closeOtherTabs(tab.id);
+  };
+
+  const requestCloseRight = (tab: Tab): void => {
+    const idx = tabs.findIndex((t) => t.id === tab.id);
+    const dirtyCount = tabs.slice(idx + 1).filter((t) => t.dirty).length;
+    if (dirtyCount > 0) {
+      setGuard({ kind: 'closeRight', tabId: tab.id, dirtyCount });
+      return;
+    }
+    closeTabsToRight(tab.id);
+  };
+
+  const requestCloseSaved = (): void => {
+    // Close Saved never touches dirty tabs — no guard needed.
+    closeSavedTabs();
+  };
+
+  const requestCloseAll = (): void => {
+    const dirtyCount = tabs.filter((t) => t.dirty).length;
+    if (dirtyCount > 0) {
+      setGuard({ kind: 'closeAll', dirtyCount });
+      return;
+    }
+    closeAllTabs();
+  };
+
+  const confirmGuard = (): void => {
+    if (!guard) return;
+    switch (guard.kind) {
+      case 'close':
+        if (guard.tabId) closeTab(guard.tabId);
+        break;
+      case 'closeOthers':
+        if (guard.tabId) closeOtherTabs(guard.tabId);
+        break;
+      case 'closeRight':
+        if (guard.tabId) closeTabsToRight(guard.tabId);
+        break;
+      case 'closeSaved':
+        closeSavedTabs();
+        break;
+      case 'closeAll':
+        closeAllTabs();
+        break;
+    }
+  };
+
+  const guardTitle = ((): string => {
+    if (!guard) return '';
+    if (guard.kind === 'close') {
+      return `'${guard.tabName ?? 'Untitled'}' has unsaved changes`;
+    }
+    return `You have ${guard.dirtyCount} unsaved tab${guard.dirtyCount === 1 ? '' : 's'}`;
+  })();
+
+  const guardDescription = ((): string => {
+    if (!guard) return '';
+    if (guard.kind === 'close') return 'Close without saving?';
+    return 'Close anyway?';
+  })();
+
+  const guardConfirmLabel = ((): string => {
+    if (!guard) return 'Close';
+    if (guard.kind === 'close') return 'Close';
+    return `Close ${guard.dirtyCount}`;
+  })();
 
   return (
     <div className="flex h-10 items-center border-b border-line bg-bg-subtle">
       <div className="flex h-full flex-1 items-stretch overflow-x-auto">
-        {tabs.map((tab) => (
-          <TabItem
-            key={tab.id}
-            tab={tab}
-            active={tab.id === activeTabId}
-            dragging={dragId === tab.id}
-            dropTarget={dropTargetId === tab.id && dragId !== null && dragId !== tab.id}
-            onSelect={() => setActiveTab(tab.id)}
-            onClose={() => closeTab(tab.id)}
-            onDragStart={() => setDragId(tab.id)}
-            onDragEnter={() => {
-              if (dragId && dragId !== tab.id) setDropTargetId(tab.id);
-            }}
-            onDragEnd={() => {
-              setDragId(null);
-              setDropTargetId(null);
-            }}
-            onDrop={() => {
-              if (dragId && dragId !== tab.id) reorderTab(dragId, tab.id);
-              setDragId(null);
-              setDropTargetId(null);
-            }}
-          />
-        ))}
+        {tabs.map((tab, index) => {
+          const isLast = index === tabs.length - 1;
+          const canCloseOthers = tabs.length > 1;
+          const canCloseRight = !isLast;
+          const canCloseSaved = savedCount > 0;
+          const canCopyUrl = tab.builder.url.trim().length > 0;
+          return (
+            <ContextMenu key={tab.id}>
+              <ContextMenuTrigger asChild>
+                <TabItem
+                  tab={tab}
+                  active={tab.id === activeTabId}
+                  dragging={dragId === tab.id}
+                  dropTarget={
+                    dropTargetId === tab.id && dragId !== null && dragId !== tab.id
+                  }
+                  onSelect={() => setActiveTab(tab.id)}
+                  onClose={() => requestClose(tab)}
+                  onDragStart={() => setDragId(tab.id)}
+                  onDragEnter={() => {
+                    if (dragId && dragId !== tab.id) setDropTargetId(tab.id);
+                  }}
+                  onDragEnd={() => {
+                    setDragId(null);
+                    setDropTargetId(null);
+                  }}
+                  onDrop={() => {
+                    if (dragId && dragId !== tab.id) reorderTab(dragId, tab.id);
+                    setDragId(null);
+                    setDropTargetId(null);
+                  }}
+                />
+              </ContextMenuTrigger>
+              <ContextMenuContent>
+                <ContextMenuItem onSelect={() => requestClose(tab)}>
+                  Close
+                </ContextMenuItem>
+                <ContextMenuItem
+                  disabled={!canCloseOthers}
+                  onSelect={() => requestCloseOthers(tab)}
+                >
+                  Close Others
+                </ContextMenuItem>
+                <ContextMenuItem
+                  disabled={!canCloseRight}
+                  onSelect={() => requestCloseRight(tab)}
+                >
+                  Close to the Right
+                </ContextMenuItem>
+                <ContextMenuItem
+                  disabled={!canCloseSaved}
+                  onSelect={requestCloseSaved}
+                >
+                  Close Saved
+                </ContextMenuItem>
+                <ContextMenuItem onSelect={requestCloseAll}>
+                  Close All
+                </ContextMenuItem>
+                <ContextMenuSeparator />
+                <ContextMenuItem onSelect={() => duplicateTab(tab.id)}>
+                  Duplicate
+                </ContextMenuItem>
+                <ContextMenuSeparator />
+                <ContextMenuItem
+                  disabled={!canCopyUrl}
+                  onSelect={() => {
+                    void navigator.clipboard.writeText(tab.builder.url);
+                  }}
+                >
+                  Copy URL
+                </ContextMenuItem>
+                {tab.kind === 'file' && tab.relPath !== null && (
+                  <ContextMenuItem
+                    onSelect={() => {
+                      setSidebarView('files');
+                      if (tab.relPath) revealInSidebar(tab.relPath);
+                    }}
+                  >
+                    Reveal in sidebar
+                  </ContextMenuItem>
+                )}
+              </ContextMenuContent>
+            </ContextMenu>
+          );
+        })}
       </div>
       <button
         onClick={newTab}
@@ -58,22 +233,20 @@ export function TabBar(): JSX.Element {
       >
         +
       </button>
+      <ConfirmDialog
+        open={guard !== null}
+        title={guardTitle}
+        description={guardDescription}
+        confirmLabel={guardConfirmLabel}
+        destructive
+        onConfirm={confirmGuard}
+        onClose={() => setGuard(null)}
+      />
     </div>
   );
 }
 
-function TabItem({
-  tab,
-  active,
-  dragging,
-  dropTarget,
-  onSelect,
-  onClose,
-  onDragStart,
-  onDragEnter,
-  onDragEnd,
-  onDrop,
-}: {
+interface TabItemOwnProps {
   tab: Tab;
   active: boolean;
   dragging: boolean;
@@ -84,12 +257,40 @@ function TabItem({
   onDragEnter: () => void;
   onDragEnd: () => void;
   onDrop: () => void;
-}): JSX.Element {
+}
+
+type TabItemProps = TabItemOwnProps &
+  Omit<
+    HTMLAttributes<HTMLDivElement>,
+    keyof TabItemOwnProps | 'onMouseDown' | 'onClick'
+  >;
+
+// forwardRef so Radix ContextMenuTrigger (asChild) can attach its ref and
+// injected event handlers to the underlying DOM node.
+const TabItem = forwardRef<HTMLDivElement, TabItemProps>(
+  function TabItem(
+    {
+      tab,
+      active,
+      dragging,
+      dropTarget,
+      onSelect,
+      onClose,
+      onDragStart,
+      onDragEnter,
+      onDragEnd,
+      onDrop,
+      ...rest
+    },
+    ref,
+  ) {
   const color = METHOD_COLOR[tab.method] ?? 'text-method-custom';
   const sending = tab.execution.status === 'sending';
 
   return (
     <div
+      ref={ref}
+      {...rest}
       draggable
       onDragStart={(e) => {
         e.dataTransfer.effectAllowed = 'move';
@@ -151,4 +352,5 @@ function TabItem({
       )}
     </div>
   );
-}
+  },
+);

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -567,13 +567,16 @@ export const useAppStore = create<AppState>((set, get) => {
     closeOtherTabs: (keepId: string) => {
       const { tabs } = get();
       if (tabs.length <= 1) return;
-      tabs.forEach((tab, index) => {
-        if (tab.id === keepId) return;
-        closedTabStack.push({ tab, index });
-        if (closedTabStack.length > CLOSED_TAB_STACK_LIMIT) closedTabStack.shift();
-      });
       const kept = tabs.find((t) => t.id === keepId);
       if (!kept) return;
+      // Push in reverse so the rightmost closed tab pops first on ⌘⇧T
+      // (VS Code most-recent-first semantics).
+      for (let i = tabs.length - 1; i >= 0; i -= 1) {
+        const tab = tabs[i]!;
+        if (tab.id === keepId) continue;
+        closedTabStack.push({ tab, index: i });
+        if (closedTabStack.length > CLOSED_TAB_STACK_LIMIT) closedTabStack.shift();
+      }
       set({ tabs: [kept], activeTabId: keepId });
     },
 
@@ -581,7 +584,7 @@ export const useAppStore = create<AppState>((set, get) => {
       const { tabs, activeTabId } = get();
       const idx = tabs.findIndex((t) => t.id === fromId);
       if (idx < 0 || idx === tabs.length - 1) return;
-      for (let i = idx + 1; i < tabs.length; i += 1) {
+      for (let i = tabs.length - 1; i > idx; i -= 1) {
         closedTabStack.push({ tab: tabs[i]!, index: i });
         if (closedTabStack.length > CLOSED_TAB_STACK_LIMIT) closedTabStack.shift();
       }
@@ -596,15 +599,19 @@ export const useAppStore = create<AppState>((set, get) => {
     closeSavedTabs: () => {
       const { tabs, activeTabId } = get();
       const keepers: Tab[] = [];
+      const removed: Array<{ tab: Tab; index: number }> = [];
       tabs.forEach((tab, index) => {
         if (tab.dirty) {
           keepers.push(tab);
           return;
         }
-        closedTabStack.push({ tab, index });
-        if (closedTabStack.length > CLOSED_TAB_STACK_LIMIT) closedTabStack.shift();
+        removed.push({ tab, index });
       });
-      if (keepers.length === tabs.length) return;
+      if (removed.length === 0) return;
+      for (let i = removed.length - 1; i >= 0; i -= 1) {
+        closedTabStack.push(removed[i]!);
+        if (closedTabStack.length > CLOSED_TAB_STACK_LIMIT) closedTabStack.shift();
+      }
       const stillActive = keepers.some((t) => t.id === activeTabId);
       set({
         tabs: keepers,
@@ -615,10 +622,10 @@ export const useAppStore = create<AppState>((set, get) => {
     closeAllTabs: () => {
       const { tabs } = get();
       if (tabs.length === 0) return;
-      tabs.forEach((tab, index) => {
-        closedTabStack.push({ tab, index });
+      for (let i = tabs.length - 1; i >= 0; i -= 1) {
+        closedTabStack.push({ tab: tabs[i]!, index: i });
         if (closedTabStack.length > CLOSED_TAB_STACK_LIMIT) closedTabStack.shift();
-      });
+      }
       set({ tabs: [], activeTabId: null });
     },
 

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -135,11 +135,20 @@ interface AppState {
 
   newTab: () => void;
   closeTab: (id: string) => void;
+  closeOtherTabs: (keepId: string) => void;
+  closeTabsToRight: (fromId: string) => void;
+  closeSavedTabs: () => void;
+  closeAllTabs: () => void;
   duplicateTab: (id: string) => void;
   setActiveTab: (id: string) => void;
   activateTabByIndex: (index: number) => void;
   reopenClosedTab: () => void;
   reorderTab: (fromId: string, toId: string) => void;
+
+  // Signal the Sidebar to expand ancestors of a file and scroll it into view.
+  revealInSidebarTick: number;
+  revealInSidebarPath: string | null;
+  revealInSidebar: (relPath: string) => void;
   openRequest: (relPath: string) => Promise<void>;
   saveActive: () => Promise<void>;
   saveActiveAs: (parentRelPath: string, name: string) => Promise<void>;
@@ -490,6 +499,8 @@ export const useAppStore = create<AppState>((set, get) => {
     focusUrlTick: 0,
     importCurlTick: 0,
     loadTestTick: 0,
+    revealInSidebarTick: 0,
+    revealInSidebarPath: null,
 
     loadRecents: async () => {
       const recents = await bridge.workspaceList();
@@ -550,6 +561,72 @@ export const useAppStore = create<AppState>((set, get) => {
       }
       set({ tabs: next, activeTabId: nextActive });
     },
+
+    // Bulk-close helpers snapshot every removed tab onto closedTabStack so
+    // ⌘⇧T reopen still works, then commit in one set() to avoid N renders.
+    closeOtherTabs: (keepId: string) => {
+      const { tabs } = get();
+      if (tabs.length <= 1) return;
+      tabs.forEach((tab, index) => {
+        if (tab.id === keepId) return;
+        closedTabStack.push({ tab, index });
+        if (closedTabStack.length > CLOSED_TAB_STACK_LIMIT) closedTabStack.shift();
+      });
+      const kept = tabs.find((t) => t.id === keepId);
+      if (!kept) return;
+      set({ tabs: [kept], activeTabId: keepId });
+    },
+
+    closeTabsToRight: (fromId: string) => {
+      const { tabs, activeTabId } = get();
+      const idx = tabs.findIndex((t) => t.id === fromId);
+      if (idx < 0 || idx === tabs.length - 1) return;
+      for (let i = idx + 1; i < tabs.length; i += 1) {
+        closedTabStack.push({ tab: tabs[i]!, index: i });
+        if (closedTabStack.length > CLOSED_TAB_STACK_LIMIT) closedTabStack.shift();
+      }
+      const next = tabs.slice(0, idx + 1);
+      const stillActive = next.some((t) => t.id === activeTabId);
+      set({
+        tabs: next,
+        activeTabId: stillActive ? activeTabId : fromId,
+      });
+    },
+
+    closeSavedTabs: () => {
+      const { tabs, activeTabId } = get();
+      const keepers: Tab[] = [];
+      tabs.forEach((tab, index) => {
+        if (tab.dirty) {
+          keepers.push(tab);
+          return;
+        }
+        closedTabStack.push({ tab, index });
+        if (closedTabStack.length > CLOSED_TAB_STACK_LIMIT) closedTabStack.shift();
+      });
+      if (keepers.length === tabs.length) return;
+      const stillActive = keepers.some((t) => t.id === activeTabId);
+      set({
+        tabs: keepers,
+        activeTabId: stillActive ? activeTabId : (keepers[0]?.id ?? null),
+      });
+    },
+
+    closeAllTabs: () => {
+      const { tabs } = get();
+      if (tabs.length === 0) return;
+      tabs.forEach((tab, index) => {
+        closedTabStack.push({ tab, index });
+        if (closedTabStack.length > CLOSED_TAB_STACK_LIMIT) closedTabStack.shift();
+      });
+      set({ tabs: [], activeTabId: null });
+    },
+
+    revealInSidebar: (relPath: string) =>
+      set({
+        revealInSidebarPath: relPath,
+        revealInSidebarTick: get().revealInSidebarTick + 1,
+      }),
 
     activateTabByIndex: (index: number) => {
       const { tabs } = get();

--- a/apps/desktop/src/renderer/src/ui/ContextMenu.tsx
+++ b/apps/desktop/src/renderer/src/ui/ContextMenu.tsx
@@ -19,16 +19,19 @@ export function ContextMenuItem({
   onSelect,
   shortcut,
   destructive = false,
+  disabled = false,
 }: {
   children: ReactNode;
   onSelect: () => void;
   shortcut?: string;
   destructive?: boolean;
+  disabled?: boolean;
 }): JSX.Element {
   return (
     <RCM.Item
       onSelect={onSelect}
-      className={`flex cursor-default items-center justify-between gap-4 rounded px-2.5 py-1.5 text-xs outline-none ${
+      disabled={disabled}
+      className={`flex cursor-default items-center justify-between gap-4 rounded px-2.5 py-1.5 text-xs outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-40 ${
         destructive
           ? 'text-method-delete data-[highlighted]:bg-method-delete/10'
           : 'text-ink-2 data-[highlighted]:bg-accent data-[highlighted]:text-white'


### PR DESCRIPTION
## Özet

Sekme barına VS Code paritesinde sağ-tık context menüsü eklendi ve kirli (dirty) sekmeler için koruma dialog'u devreye alındı.

### Menü öğeleri
- **Close** - sadece bu sekmeyi kapatır
- **Close Others** - tek sekme kaldığında disabled
- **Close to the Right** - en sağdaki sekmede disabled
- **Close Saved** - hiç kaydedilmiş sekme yoksa disabled
- **Close All**
- **Duplicate**
- **Copy URL** - URL boşsa disabled
- **Reveal in sidebar** - yalnız `kind === 'file'` sekmelerinde görünür; Files sidebar'ında dosyanın atalarını açıp satırı görünüre kaydırır

### Dirty guard
Kirli sekme içeren her kapatma eylemi önce `ConfirmDialog` üzerinden VS Code tarzı "unsaved changes" onayı ister:
- Tek kirli sekme: `'{isim}' has unsaved changes` / Close / Cancel
- Toplu: `You have {N} unsaved tabs` / Close {N} / Cancel

Cancel tüm batch'i iptal eder.

### Store eklemeleri
- `closeOtherTabs`, `closeTabsToRight`, `closeSavedTabs`, `closeAllTabs` - her biri kaldırılan sekmeleri `closedTabStack`'e iter (⌘⇧T reopen bozulmasın) ve tek `set()` ile commit eder
- `revealInSidebarTick` / `revealInSidebarPath` / `revealInSidebar()` - mevcut `focusUrlTick` pattern'ini takip eder
- Sidebar, tick değişince hedef yolun tüm atalarını açar ve satırı `scrollIntoView` ile görünüre çeker

### Doğrulama
- `pnpm -r typecheck` ✓
- `pnpm -r test` ✓ (195 passed + 7 skipped, değişmedi)
- `pnpm --filter=@scrapeman/desktop build` ✓
- Manuel render testi için dosya yok (yeni framework eklenmedi)