### PR TITLE
fix(vars): highlight undefined variables + send empty string

### DIFF
--- a/apps/desktop/src/renderer/src/ui/HighlightedInput.tsx
+++ b/apps/desktop/src/renderer/src/ui/HighlightedInput.tsx
@@ -67,6 +67,10 @@ export const HighlightedInput = forwardRef<HTMLInputElement, HighlightedInputPro
     useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
 
     const variables = useAvailableVariables();
+    const variableNames = useMemo(
+      () => new Set(variables.map((v) => v.name)),
+      [variables],
+    );
     const [auto, setAuto] = useState<AutocompleteState>(CLOSED_AUTOCOMPLETE);
     const [popoverRect, setPopoverRect] = useState<{
       top: number;
@@ -250,7 +254,7 @@ export const HighlightedInput = forwardRef<HTMLInputElement, HighlightedInputPro
           className={`pointer-events-none absolute inset-0 flex items-center overflow-hidden ${padding} ${baseInner} text-ink-1`}
         >
           <span className="block whitespace-pre">
-            {value.length > 0 ? renderHighlighted(value) : null}
+            {value.length > 0 ? renderHighlighted(value, variableNames) : null}
           </span>
         </div>
         <input
@@ -333,7 +337,10 @@ export const HighlightedInput = forwardRef<HTMLInputElement, HighlightedInputPro
   },
 );
 
-function renderHighlighted(text: string): ReactNode[] {
+function renderHighlighted(
+  text: string,
+  knownVariables: ReadonlySet<string>,
+): ReactNode[] {
   const parts: ReactNode[] = [];
   let last = 0;
   VAR_PATTERN.lastIndex = 0;
@@ -342,10 +349,19 @@ function renderHighlighted(text: string): ReactNode[] {
     if (match.index > last) {
       parts.push(text.slice(last, match.index));
     }
+    // Strip the `{{` `}}` and optional whitespace to match against the
+    // available-variables list. Unknown tokens render in the delete/red
+    // palette so users notice they will be sent as empty at request time.
+    const name = match[0].slice(2, -2).trim();
+    const isKnown = knownVariables.has(name);
+    const cls = isKnown
+      ? 'rounded-sm bg-accent-soft px-0.5 font-medium text-accent'
+      : 'rounded-sm bg-method-delete/10 px-0.5 font-medium text-method-delete';
     parts.push(
       <span
         key={`v-${match.index}`}
-        className="rounded-sm bg-accent-soft px-0.5 font-medium text-accent"
+        className={cls}
+        {...(isKnown ? {} : { title: 'undefined variable' })}
       >
         {match[0]}
       </span>,

--- a/packages/http-core/src/variables/resolve.ts
+++ b/packages/http-core/src/variables/resolve.ts
@@ -32,12 +32,15 @@ export interface ResolveOutcome {
 }
 
 export function resolveString(input: string, ctx: VariableContext): string {
-  return input.replace(VAR_PATTERN, (match, name: string) => {
+  return input.replace(VAR_PATTERN, (_match, name: string) => {
     const value = ctx.variables[name];
     if (value !== undefined) return value;
     const builtin = BUILTIN_VARIABLES[name];
     if (builtin) return builtin();
-    return match;
+    // Undefined variable: drop the token so the outgoing request does not
+    // contain a literal `{{var}}`. `findUnresolved` still reports it via
+    // resolveRequest so the UI can warn.
+    return '';
   });
 }
 

--- a/packages/http-core/tests/variables.test.ts
+++ b/packages/http-core/tests/variables.test.ts
@@ -31,8 +31,8 @@ describe('resolveString', () => {
     expect(resolveString('Bearer {{ token }}', ctx)).toBe('Bearer secret-token');
   });
 
-  it('leaves unknown variables untouched', () => {
-    expect(resolveString('{{unknown}}/path', ctx)).toBe('{{unknown}}/path');
+  it('replaces unknown variables with an empty string', () => {
+    expect(resolveString('{{unknown}}/path', ctx)).toBe('/path');
   });
 
   it('passes through strings with no variables', () => {
@@ -140,6 +140,20 @@ describe('resolveRequest', () => {
       type: 'json',
       content: '{"id":"42","key":"k_abc"}',
     });
+  });
+
+  it('drops undefined variables from URL and headers at send-time', () => {
+    const req: ScrapemanRequest = {
+      scrapeman: FORMAT_VERSION,
+      meta: { name: 'broken' },
+      method: 'GET',
+      url: '{{baseUrl}}/{{missing}}/end',
+      headers: { 'X-Key': '{{alsoMissing}}', 'X-Ok': '{{apiKey}}' },
+    };
+    const { request, unresolved } = resolveRequest(req, ctx);
+    expect(request.url).toBe('https://api.example.com//end');
+    expect(request.headers).toEqual({ 'X-Key': '', 'X-Ok': 'k_abc' });
+    expect(unresolved.sort()).toEqual(['alsoMissing', 'missing']);
   });
 
   it('reports unresolved variables aggregated from everywhere', () => {


### PR DESCRIPTION
## Özet

Kapatır #36. Tanımsız `{{var}}` token'ları iki yerde sessizce bozuluyordu:

1. **UI**: resolved variable ile aynı renkte gözüküyordu — typo fark edilmiyordu.
2. **Wire**: send sırasında literal `{{var}}` string'i gidiyordu — endpoint'e geçersiz değer düşüyordu.

## Değişiklikler

- **`resolveString`**: tanımsız token → `''`. Built-in'ler ve `findUnresolved` raporu korundu, UI yine eksik isimleri biliyor.
- **`HighlightedInput.renderHighlighted`**: tanıdık variable set'ini parametre alıyor; bilinmeyen token'lar `bg-method-delete/10 text-method-delete` + `title="undefined variable"` tooltip'iyle kırmızı render ediliyor. Bilinen token'lar eski `bg-accent-soft text-accent` stilinde kalıyor.
- **Tests**: URL + header value'da missing var → empty string; defined var regression guard; `unresolved` dizisi hâlâ eksik isimleri listeliyor.

## Doğrulama

- `pnpm -r typecheck` ✅
- `pnpm -r test` → **196 passed** + 7 skipped (+1 net new)
- `pnpm --filter=@scrapeman/desktop build` ✅
- Pre-push hook tekrarı yeşil