### PR TITLE
feat: per-request git-sync toggle (closes #42)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ The full marketing site lives at **[scrapeman.app](https://scrapeman.app)** and 
 - Body sidecar: payloads >= 4KB auto-promoted to `files/<slug>.body.<ext>`
 - Variable + collection tree lives in a user-chosen workspace folder — scrapeman never writes outside it
 - Live file-watcher (chokidar) reloads external edits with self-write suppression
+- **Per-request sync toggle**: right-click a request → "Stop syncing to git" to keep it local only. Backed by `.git/info/exclude` (never pushed) + `git rm --cached`, so teammates never see it. `⌘⇧H` toggles on the active tab. A crossed-eye icon marks unsynced requests in the sidebar and on the tab. If you later `git add` the file yourself, scrapeman notices and the icon clears automatically
 
 ### Local history
 - Every sent request captured to a per-workspace JSONL file under app data dir (never the workspace)
@@ -141,7 +142,7 @@ The full marketing site lives at **[scrapeman.app](https://scrapeman.app)** and 
 - Resizable + orientable split (horizontal ↔ vertical, persistent)
 - Resizable sidebar + history panel
 - Dark mode with CSS variable tokens, system preference fallback
-- Cross-platform keyboard shortcuts: ⌘T new tab, ⌘W close, ⌘↵ send, ⌘S save (with draft save-as flow)
+- Cross-platform keyboard shortcuts: ⌘T new tab, ⌘W close, ⌘↵ send, ⌘S save (with draft save-as flow), ⌘⇧H toggle git-sync on active request
 - Postman-light design system, Inter + Geist Mono fonts
 
 ## Install

--- a/apps/desktop/src/main/git.ts
+++ b/apps/desktop/src/main/git.ts
@@ -5,7 +5,7 @@
 
 import { execFile } from 'node:child_process';
 import { promises as fsp } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { parsePorcelainStatus } from '@scrapeman/http-core';
 import type {
@@ -238,6 +238,146 @@ export async function gitCommit(
     throw new GitError('Commit message is required', '', null);
   }
   await run(workspacePath, ['commit', '-m', message]);
+}
+
+// Local-only hide feature (issue #42): mark a request as ignored via
+// .git/info/exclude so it stays on disk for the current user but is never
+// synced via .gitignore (which itself would be tracked). Entries live in a
+// marker block so we can list and unhide them cleanly without clobbering
+// anything the user has in the rest of the file.
+const EXCLUDE_BEGIN = '# >>> scrapeman:hidden (managed — do not edit)';
+const EXCLUDE_END = '# <<< scrapeman:hidden';
+
+async function gitDir(workspacePath: string): Promise<string> {
+  const { stdout } = await run(workspacePath, ['rev-parse', '--git-dir']);
+  const dir = stdout.trim();
+  return dir.startsWith('/') ? dir : join(workspacePath, dir);
+}
+
+async function readExcludeFile(
+  workspacePath: string,
+): Promise<{ path: string; lines: string[] }> {
+  const path = join(await gitDir(workspacePath), 'info', 'exclude');
+  try {
+    const text = await fsp.readFile(path, 'utf8');
+    return { path, lines: text.split('\n') };
+  } catch {
+    return { path, lines: [] };
+  }
+}
+
+function parseHiddenBlock(lines: string[]): {
+  before: string[];
+  hidden: string[];
+  after: string[];
+} {
+  const begin = lines.indexOf(EXCLUDE_BEGIN);
+  if (begin < 0) return { before: lines, hidden: [], after: [] };
+  const end = lines.indexOf(EXCLUDE_END, begin + 1);
+  if (end < 0) return { before: lines, hidden: [], after: [] };
+  const hidden: string[] = [];
+  for (let i = begin + 1; i < end; i += 1) {
+    const line = lines[i]!.trim();
+    if (!line || line.startsWith('#')) continue;
+    hidden.push(line.startsWith('/') ? line.slice(1) : line);
+  }
+  return {
+    before: lines.slice(0, begin),
+    hidden,
+    after: lines.slice(end + 1),
+  };
+}
+
+function serializeExcludeFile(
+  before: string[],
+  hidden: string[],
+  after: string[],
+): string {
+  const pieces: string[] = [];
+  if (before.length > 0) pieces.push(before.join('\n').replace(/\n+$/, ''));
+  if (hidden.length > 0) {
+    const block = [EXCLUDE_BEGIN, ...hidden.map((p) => `/${p}`), EXCLUDE_END];
+    pieces.push(block.join('\n'));
+  }
+  if (after.length > 0) pieces.push(after.join('\n').replace(/^\n+/, ''));
+  return pieces.filter((p) => p.length > 0).join('\n\n') + '\n';
+}
+
+// "Whatever appears in git is unhidden": if any entry in our managed block
+// is currently tracked by git (e.g. the user ran `git add` manually, or we
+// failed to `rm --cached` earlier), drop it from the exclude file and
+// report it as not-hidden. This makes hide/unhide self-consistent with the
+// index — the only source of truth that matters for sync.
+export async function gitLocalHiddenList(
+  workspacePath: string,
+): Promise<string[]> {
+  if (!(await isInsideWorkTree(workspacePath))) return [];
+  const { path, lines } = await readExcludeFile(workspacePath);
+  const { before, hidden, after } = parseHiddenBlock(lines);
+  if (hidden.length === 0) return [];
+
+  const tracked = new Set<string>();
+  try {
+    const { stdout } = await run(workspacePath, [
+      'ls-files',
+      '-z',
+      '--',
+      ...hidden,
+    ]);
+    for (const entry of stdout.split('\0')) {
+      if (entry) tracked.add(entry);
+    }
+  } catch {
+    // ls-files shouldn't fail, but if it does treat nothing as tracked.
+  }
+
+  const stillHidden = hidden.filter((p) => !tracked.has(p));
+  if (stillHidden.length !== hidden.length) {
+    await fsp.writeFile(
+      path,
+      serializeExcludeFile(before, stillHidden, after),
+      'utf8',
+    );
+  }
+  return stillHidden;
+}
+
+export async function gitLocalHide(
+  workspacePath: string,
+  relPath: string,
+): Promise<void> {
+  if (!(await isInsideWorkTree(workspacePath))) {
+    throw new GitError(
+      'Hiding requires a git repository. Run `git init` in this workspace first.',
+      '',
+      null,
+    );
+  }
+  const { path, lines } = await readExcludeFile(workspacePath);
+  const { before, hidden, after } = parseHiddenBlock(lines);
+  if (!hidden.includes(relPath)) hidden.push(relPath);
+  await fsp.mkdir(dirname(path), { recursive: true });
+  await fsp.writeFile(path, serializeExcludeFile(before, hidden, after), 'utf8');
+
+  // If the file is already tracked, remove it from the index so the hide
+  // actually takes effect. `--cached` leaves the working-tree file alone.
+  try {
+    await run(workspacePath, ['rm', '--cached', '--quiet', '--', relPath]);
+  } catch {
+    // Not tracked — nothing to do.
+  }
+}
+
+export async function gitLocalUnhide(
+  workspacePath: string,
+  relPath: string,
+): Promise<void> {
+  if (!(await isInsideWorkTree(workspacePath))) return;
+  const { path, lines } = await readExcludeFile(workspacePath);
+  const { before, hidden, after } = parseHiddenBlock(lines);
+  const next = hidden.filter((p) => p !== relPath);
+  if (next.length === hidden.length) return;
+  await fsp.writeFile(path, serializeExcludeFile(before, next, after), 'utf8');
 }
 
 export async function gitPush(

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -45,6 +45,9 @@ import {
   gitCommit,
   gitPush,
   gitPull,
+  gitLocalHiddenList,
+  gitLocalHide,
+  gitLocalUnhide,
   GitError,
 } from './git.js';
 
@@ -707,6 +710,33 @@ app.whenReady().then(() => {
   );
   ipcMain.handle('git:push', (_e, workspacePath: string) =>
     gitPush(workspacePath),
+  );
+  ipcMain.handle('git:localHiddenList', async (_e, workspacePath: string) => {
+    try {
+      return await gitLocalHiddenList(workspacePath);
+    } catch (err) {
+      throw toGitError(err);
+    }
+  });
+  ipcMain.handle(
+    'git:localHide',
+    async (_e, workspacePath: string, relPath: string) => {
+      try {
+        await gitLocalHide(workspacePath, relPath);
+      } catch (err) {
+        throw toGitError(err);
+      }
+    },
+  );
+  ipcMain.handle(
+    'git:localUnhide',
+    async (_e, workspacePath: string, relPath: string) => {
+      try {
+        await gitLocalUnhide(workspacePath, relPath);
+      } catch (err) {
+        throw toGitError(err);
+      }
+    },
   );
   ipcMain.handle('git:pull', (_e, workspacePath: string) =>
     gitPull(workspacePath),

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -216,6 +216,12 @@ const api: ScrapemanBridge = {
     ipcRenderer.invoke('git:push', workspacePath) as Promise<GitOpResult>,
   gitPull: (workspacePath: string) =>
     ipcRenderer.invoke('git:pull', workspacePath) as Promise<GitOpResult>,
+  gitLocalHiddenList: (workspacePath: string) =>
+    ipcRenderer.invoke('git:localHiddenList', workspacePath) as Promise<string[]>,
+  gitLocalHide: (workspacePath: string, relPath: string) =>
+    ipcRenderer.invoke('git:localHide', workspacePath, relPath) as Promise<void>,
+  gitLocalUnhide: (workspacePath: string, relPath: string) =>
+    ipcRenderer.invoke('git:localUnhide', workspacePath, relPath) as Promise<void>,
 };
 
 contextBridge.exposeInMainWorld('scrapeman', api);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -32,6 +32,9 @@ export function App(): JSX.Element {
   const send = useAppStore((s) => s.send);
   const saveOrPrompt = useAppStore((s) => s.saveOrPrompt);
   const focusUrl = useAppStore((s) => s.focusUrl);
+  const toggleHiddenRequest = useAppStore((s) => s.toggleHiddenRequest);
+  const tabs = useAppStore((s) => s.tabs);
+  const isRepo = useAppStore((s) => s.gitStatus?.isRepo === true);
 
   useEffect(() => {
     void loadRecents();
@@ -46,7 +49,10 @@ export function App(): JSX.Element {
   useEffect(() => {
     const unsubscribe = bridge.onWorkspaceEvent((event) => {
       if (!workspace || event.workspacePath !== workspace.path) return;
-      if (event.type === 'tree-changed') void refreshTree();
+      if (event.type === 'tree-changed') {
+        void refreshTree();
+        void useAppStore.getState().loadHiddenRequests();
+      }
       if (event.type === 'environments-changed') void loadEnvironments();
     });
     return unsubscribe;
@@ -84,6 +90,20 @@ export function App(): JSX.Element {
               description: 'Reopen closed tab',
               handler: () => reopenClosedTab(),
             },
+            ...(isRepo
+              ? [
+                  {
+                    combo: 'mod+shift+h',
+                    description: 'Toggle sync with git',
+                    handler: (): void => {
+                      const active = tabs.find((t) => t.id === activeTabId);
+                      if (active?.kind === 'file' && active.relPath) {
+                        void toggleHiddenRequest(active.relPath);
+                      }
+                    },
+                  },
+                ]
+              : []),
             ...([1, 2, 3, 4, 5, 6, 7, 8, 9] as const).map((n) => ({
               combo: `mod+${n}` as const,
               description: `Switch to tab ${n}`,
@@ -101,6 +121,9 @@ export function App(): JSX.Element {
       send,
       saveOrPrompt,
       focusUrl,
+      toggleHiddenRequest,
+      tabs,
+      isRepo,
       paletteOpen,
     ],
   );

--- a/apps/desktop/src/renderer/src/commands.ts
+++ b/apps/desktop/src/renderer/src/commands.ts
@@ -24,6 +24,9 @@ export function useCommands(extras: CommandExtras): Command[] {
   const focusUrl = useAppStore((s) => s.focusUrl);
   const openImportCurl = useAppStore((s) => s.openImportCurl);
   const openLoadTest = useAppStore((s) => s.openLoadTest);
+  const toggleHiddenRequest = useAppStore((s) => s.toggleHiddenRequest);
+  const tabs = useAppStore((s) => s.tabs);
+  const isRepo = useAppStore((s) => s.gitStatus?.isRepo === true);
 
   return useMemo<Command[]>(
     () => [
@@ -78,6 +81,22 @@ export function useCommands(extras: CommandExtras): Command[] {
           if (activeTabId) duplicateTab(activeTabId);
         },
       },
+      ...(isRepo
+        ? [
+            {
+              id: 'request.toggle-hidden',
+              title: 'Toggle sync with git (on/off)',
+              section: 'Request',
+              shortcut: 'mod+shift+h',
+              run: () => {
+                const active = tabs.find((t) => t.id === activeTabId);
+                if (active?.kind === 'file' && active.relPath) {
+                  void toggleHiddenRequest(active.relPath);
+                }
+              },
+            },
+          ]
+        : []),
       {
         id: 'view.focus-url',
         title: 'Focus URL bar',
@@ -108,6 +127,9 @@ export function useCommands(extras: CommandExtras): Command[] {
       focusUrl,
       openImportCurl,
       openLoadTest,
+      toggleHiddenRequest,
+      tabs,
+      isRepo,
       extras,
     ],
   );

--- a/apps/desktop/src/renderer/src/components/Sidebar.tsx
+++ b/apps/desktop/src/renderer/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   ContextMenuTrigger,
 } from '../ui/ContextMenu.js';
 import { ConfirmDialog, PromptDialog } from '../ui/Dialog.js';
+import { EyeOffIcon } from '../ui/EyeOffIcon.js';
 import { HistoryPanel } from './HistoryPanel.js';
 import { SourceControlPanel } from './SourceControlPanel.js';
 import { SplitPane } from './SplitPane.js';
@@ -56,6 +57,8 @@ export function Sidebar(): JSX.Element {
   const deleteNode = useAppStore((s) => s.deleteNode);
   const moveNode = useAppStore((s) => s.moveNode);
   const gitStatus = useAppStore((s) => s.gitStatus);
+  const hiddenRequests = useAppStore((s) => s.hiddenRequests);
+  const toggleHiddenRequest = useAppStore((s) => s.toggleHiddenRequest);
   const view = useAppStore((s) => s.sidebarView);
   const setView = useAppStore((s) => s.setSidebarView);
   const revealTick = useAppStore((s) => s.revealInSidebarTick);
@@ -147,6 +150,8 @@ export function Sidebar(): JSX.Element {
           onPick={() => void pickAndOpenWorkspace()}
           root={root}
           gitStatusByPath={gitStatusByPath}
+          hiddenRequests={hiddenRequests}
+          onToggleHidden={(relPath) => void toggleHiddenRequest(relPath)}
           setDialog={setDialog}
           selectedFolder={selectedFolder}
           onSelectFolder={setSelectedFolder}
@@ -215,6 +220,8 @@ interface FilesViewProps {
   onPick: () => void;
   root: NonNullable<ReturnType<typeof useAppStore.getState>['root']>;
   gitStatusByPath: Map<string, GitFileChangeStatus>;
+  hiddenRequests: Set<string>;
+  onToggleHidden: (relPath: string) => void;
   setDialog: (dialog: DialogState) => void;
   selectedFolder: string;
   onSelectFolder: (relPath: string) => void;
@@ -230,6 +237,8 @@ function FilesView({
   onPick,
   root,
   gitStatusByPath,
+  hiddenRequests,
+  onToggleHidden,
   setDialog,
   selectedFolder,
   onSelectFolder,
@@ -308,6 +317,8 @@ function FilesView({
                     node={child}
                     depth={0}
                     gitStatusByPath={gitStatusByPath}
+                    hiddenRequests={hiddenRequests}
+                    onToggleHidden={onToggleHidden}
                     selectedFolder={selectedFolder}
                     onSelectFolder={onSelectFolder}
                     onMoveRequest={onMoveRequest}
@@ -338,6 +349,8 @@ interface TreeNodeProps {
   node: CollectionNode;
   depth: number;
   gitStatusByPath: Map<string, GitFileChangeStatus>;
+  hiddenRequests: Set<string>;
+  onToggleHidden: (relPath: string) => void;
   selectedFolder: string;
   onSelectFolder: (relPath: string) => void;
   onMoveRequest: (relPath: string, newParent: string) => void;
@@ -354,6 +367,8 @@ function TreeNode({
   node,
   depth,
   gitStatusByPath,
+  hiddenRequests,
+  onToggleHidden,
   selectedFolder,
   onSelectFolder,
   onMoveRequest,
@@ -402,6 +417,7 @@ function TreeNode({
   const tabs = useAppStore((s) => s.tabs);
   const activeTabId = useAppStore((s) => s.activeTabId);
   const openRequest = useAppStore((s) => s.openRequest);
+  const isRepo = useAppStore((s) => s.gitStatus?.isRepo === true);
 
   const fileTab =
     node.kind === 'request'
@@ -409,6 +425,7 @@ function TreeNode({
       : null;
   const dirty = fileTab?.dirty === true;
   const active = fileTab !== null && fileTab.id === activeTabId;
+  const hidden = node.kind === 'request' && hiddenRequests.has(node.relPath);
   const indent = 10 + depth * 14;
 
   if (node.kind === 'folder') {
@@ -485,6 +502,8 @@ function TreeNode({
               node={child}
               depth={depth + 1}
               gitStatusByPath={gitStatusByPath}
+              hiddenRequests={hiddenRequests}
+              onToggleHidden={onToggleHidden}
               selectedFolder={selectedFolder}
               onSelectFolder={onSelectFolder}
               onMoveRequest={onMoveRequest}
@@ -534,7 +553,15 @@ function TreeNode({
           >
             {node.method.slice(0, 6)}
           </span>
-          <span className="flex-1 truncate">{node.name}</span>
+          <span className={`flex-1 truncate ${hidden ? 'italic opacity-60' : ''}`}>
+            {node.name}
+          </span>
+          {hidden && (
+            <EyeOffIcon
+              className="h-3.5 w-3.5 text-ink-3"
+              title="Sync: off (local only, not pushed to git)"
+            />
+          )}
           {(() => {
             const gitStatus =
               node.kind === 'request'
@@ -563,6 +590,14 @@ function TreeNode({
           Open
         </ContextMenuItem>
         <ContextMenuSeparator />
+        {isRepo && (
+          <>
+            <ContextMenuItem onSelect={() => onToggleHidden(node.relPath)}>
+              {hidden ? 'Start syncing to git' : 'Stop syncing to git'}
+            </ContextMenuItem>
+            <ContextMenuSeparator />
+          </>
+        )}
         <ContextMenuItem onSelect={() => onRename(node.relPath, node.name)}>
           Rename
         </ContextMenuItem>

--- a/apps/desktop/src/renderer/src/components/TabBar.tsx
+++ b/apps/desktop/src/renderer/src/components/TabBar.tsx
@@ -9,6 +9,7 @@ import {
   ContextMenuTrigger,
 } from '../ui/ContextMenu.js';
 import { ConfirmDialog } from '../ui/Dialog.js';
+import { EyeOffIcon } from '../ui/EyeOffIcon.js';
 
 const METHOD_COLOR: Record<string, string> = {
   GET: 'text-method-get',
@@ -37,6 +38,7 @@ interface GuardState {
 export function TabBar(): JSX.Element {
   const tabs = useAppStore((s) => s.tabs);
   const activeTabId = useAppStore((s) => s.activeTabId);
+  const hiddenRequests = useAppStore((s) => s.hiddenRequests);
   const newTab = useAppStore((s) => s.newTab);
   const closeTab = useAppStore((s) => s.closeTab);
   const closeOtherTabs = useAppStore((s) => s.closeOtherTabs);
@@ -155,6 +157,11 @@ export function TabBar(): JSX.Element {
                 <TabItem
                   tab={tab}
                   active={tab.id === activeTabId}
+                  hidden={
+                    tab.kind === 'file' &&
+                    tab.relPath !== null &&
+                    hiddenRequests.has(tab.relPath)
+                  }
                   dragging={dragId === tab.id}
                   dropTarget={
                     dropTargetId === tab.id && dragId !== null && dragId !== tab.id
@@ -252,6 +259,7 @@ export function TabBar(): JSX.Element {
 interface TabItemOwnProps {
   tab: Tab;
   active: boolean;
+  hidden: boolean;
   dragging: boolean;
   dropTarget: boolean;
   onSelect: () => void;
@@ -275,6 +283,7 @@ const TabItem = forwardRef<HTMLDivElement, TabItemProps>(
     {
       tab,
       active,
+      hidden,
       dragging,
       dropTarget,
       onSelect,
@@ -332,7 +341,15 @@ const TabItem = forwardRef<HTMLDivElement, TabItemProps>(
       <span className={`font-mono text-[10px] font-semibold ${color}`}>
         {tab.method.slice(0, 6)}
       </span>
-      <span className="flex-1 truncate">{tab.name}</span>
+      <span className={`flex-1 truncate ${hidden ? 'italic opacity-70' : ''}`}>
+        {tab.name}
+      </span>
+      {hidden && (
+        <EyeOffIcon
+          className="h-3.5 w-3.5 text-ink-3"
+          title="Sync: off (local only, not pushed to git)"
+        />
+      )}
       {sending && (
         <span
           title="Request in flight"

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -208,6 +208,13 @@ interface AppState {
   commitChanges: (message: string) => Promise<void>;
   gitPush: () => Promise<void>;
   gitPull: () => Promise<void>;
+
+  // Local-hide (issue #42): requests the user has hidden from git sync via
+  // .git/info/exclude. Scoped per workspace; reloaded whenever the tree or
+  // git status refreshes.
+  hiddenRequests: Set<string>;
+  loadHiddenRequests: () => Promise<void>;
+  toggleHiddenRequest: (relPath: string) => Promise<void>;
 }
 
 function freshHeader(): HeaderRow {
@@ -493,6 +500,7 @@ export const useAppStore = create<AppState>((set, get) => {
     gitLoaded: false,
     gitError: null,
     gitBusy: false,
+    hiddenRequests: new Set<string>(),
     sidebarView: 'files',
     setSidebarView: (view) => set({ sidebarView: view }),
     saveDialogOpen: false,
@@ -525,11 +533,13 @@ export const useAppStore = create<AppState>((set, get) => {
         gitStatus: null,
         gitLoaded: false,
         gitError: null,
+        hiddenRequests: new Set<string>(),
       });
       await get().loadRecents();
       await get().loadEnvironments();
       await get().loadHistory();
       await get().loadGitStatus();
+      await get().loadHiddenRequests();
     },
 
     refreshTree: async () => {
@@ -1334,6 +1344,37 @@ export const useAppStore = create<AppState>((set, get) => {
       }
       await get().loadGitStatus();
       set({ gitBusy: false, gitError: actionError });
+    },
+
+    loadHiddenRequests: async () => {
+      const workspace = get().workspace;
+      if (!workspace) {
+        set({ hiddenRequests: new Set<string>() });
+        return;
+      }
+      try {
+        const list = await bridge.gitLocalHiddenList(workspace.path);
+        set({ hiddenRequests: new Set(list) });
+      } catch {
+        set({ hiddenRequests: new Set<string>() });
+      }
+    },
+
+    toggleHiddenRequest: async (relPath: string) => {
+      const workspace = get().workspace;
+      if (!workspace) return;
+      const current = get().hiddenRequests;
+      try {
+        if (current.has(relPath)) {
+          await bridge.gitLocalUnhide(workspace.path, relPath);
+        } else {
+          await bridge.gitLocalHide(workspace.path, relPath);
+        }
+        await get().loadHiddenRequests();
+        await get().loadGitStatus();
+      } catch (err) {
+        set({ gitError: err instanceof Error ? err.message : String(err) });
+      }
     },
   };
 });

--- a/apps/desktop/src/renderer/src/ui/EyeOffIcon.tsx
+++ b/apps/desktop/src/renderer/src/ui/EyeOffIcon.tsx
@@ -1,0 +1,26 @@
+interface EyeOffIconProps {
+  className?: string;
+  title?: string;
+}
+
+export function EyeOffIcon({ className, title }: EyeOffIconProps): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden={title ? undefined : true}
+      role={title ? 'img' : undefined}
+    >
+      {title && <title>{title}</title>}
+      <path d="M9.88 9.88a3 3 0 0 0 4.24 4.24" />
+      <path d="M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 11 7 11 7a13.16 13.16 0 0 1-1.67 2.68" />
+      <path d="M6.61 6.61A13.526 13.526 0 0 0 1 12s4 7 11 7a9.74 9.74 0 0 0 5.39-1.61" />
+      <line x1="2" y1="2" x2="22" y2="22" />
+    </svg>
+  );
+}

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -506,4 +506,7 @@ export interface ScrapemanBridge {
   gitCommit: (workspacePath: string, message: string) => Promise<void>;
   gitPush: (workspacePath: string) => Promise<GitOpResult>;
   gitPull: (workspacePath: string) => Promise<GitOpResult>;
+  gitLocalHiddenList: (workspacePath: string) => Promise<string[]>;
+  gitLocalHide: (workspacePath: string, relPath: string) => Promise<void>;
+  gitLocalUnhide: (workspacePath: string, relPath: string) => Promise<void>;
 }


### PR DESCRIPTION
Closes #42.

## What

A per-request "sync with git: on/off" toggle. When off, the request stays on disk and in the sidebar/tabs as usual, but git won't push it to teammates. Meant for personal scratch requests — debugging calls, local-only auth probes, half-baked experiments — that you don't want to commit but also don't want to delete.

## Why this approach

The issue proposed a local-only mechanism because `.gitignore` itself syncs to the remote, leaking the ignore list. The natural fit is `.git/info/exclude`: git's built-in per-clone ignore file that is *never* pushed. We layer on top of it rather than inventing a new config file.

## How it works

**Backend (`apps/desktop/src/main/git.ts`)**

Three new helpers, all gated on "is this a git repo":

- `gitLocalHide(workspacePath, relPath)` — appends the path to a managed block inside `.git/info/exclude`:
  ```
  # >>> scrapeman:hidden (managed — do not edit)
  /collections/users/probe.req.yaml
  # <<< scrapeman:hidden
  ```
  Then runs `git rm --cached -- <relPath>` so any previously-tracked copy leaves the index (the file on disk is untouched). Everything outside the marker block in `.git/info/exclude` is preserved.
- `gitLocalUnhide(workspacePath, relPath)` — removes the entry from the managed block.
- `gitLocalHiddenList(workspacePath)` — reads the managed block **and** intersects with `git ls-files` on those paths. Anything git is currently tracking gets dropped from the returned list *and* rewritten out of the exclude file. So if you `git add` the file in a terminal, scrapeman notices on the next refresh and the icon clears automatically. "Whatever appears in git is unhidden."

IPC wired through `git:localHide`, `git:localUnhide`, `git:localHiddenList`. Bridge typed in `@scrapeman/shared-types`.

**State (`store.ts`)**

- `hiddenRequests: Set<string>` keyed by workspace-relative path.
- `loadHiddenRequests()` — called on workspace open and on every `tree-changed` workspace-watcher event, so external `git add`/`git rm` get picked up.
- `toggleHiddenRequest(relPath)` — flips state and refreshes git status.

**UI**

- `ui/EyeOffIcon.tsx` — a small inline SVG "crossed eye" icon (no new dependency).
- Sidebar (`components/Sidebar.tsx`): unsynced request rows render italic/dimmed with the icon. Right-click menu shows **"Stop syncing to git"** or **"Start syncing to git"** depending on current state. Menu entry is hidden entirely when the workspace is not a git repo.
- TabBar (`components/TabBar.tsx`): the same icon + italic title appears on the tab itself when the underlying file is unsynced — so you can see at a glance that the request you're editing won't be pushed.
- Command palette + shortcut: **⌘⇧H** (Ctrl+Shift+H on Win/Linux) toggles the active tab. Both the palette entry and the keybinding only register when `gitStatus.isRepo === true`, so non-repo workspaces don't advertise the feature at all.

## How to use

1. Right-click any saved request in the sidebar → **Stop syncing to git**. An eye-off icon appears on the row and the tab; the request's row goes italic.
2. Run `git status` — the file is gone from the list. Already-tracked files get removed from the index via `git rm --cached` (working copy preserved).
3. To reverse: right-click → **Start syncing to git**, or `⌘⇧H` on the active tab, or just `git add <path>` from a terminal (scrapeman auto-detects and clears the icon on next refresh).
4. Non-repo workspaces never see any of this — the menu item, command, and shortcut all disappear.

## Test plan

- [ ] Open a workspace that's a git repo, create a request, right-click → Stop syncing → confirm it disappears from `git status` and the row goes italic with the eye-off icon
- [ ] Open the same request in a tab → tab shows the eye-off icon and italic title
- [ ] Press `⌘⇧H` on the tab → toggles back to synced
- [ ] `git add <file>` manually from a terminal while it's marked unsynced → reopen workspace or trigger a tree refresh → icon clears automatically, `.git/info/exclude` managed block no longer lists the path
- [ ] Open a workspace that is NOT a git repo → confirm the sidebar context menu has no sync entry, `⌘⇧H` is a no-op, and the command palette doesn't list the toggle
- [ ] Verify nothing outside the `# >>> scrapeman:hidden` / `# <<< scrapeman:hidden` markers in `.git/info/exclude` is modified by hide/unhide round-trips