### PR TITLE
feat(updater): Phase 1 update check banner

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -32,6 +32,7 @@ import type {
   ScrapemanRequest,
 } from '@scrapeman/shared-types';
 import { WorkspaceManager } from './workspace-manager.js';
+import { initAutoUpdater } from './updater.js';
 import {
   gitIsRepo,
   gitLog,
@@ -97,7 +98,7 @@ function rememberFullBody(requestId: string, bytes: Uint8Array): void {
   }
 }
 
-function createWindow(): void {
+function createWindow(): BrowserWindow {
   const win = new BrowserWindow({
     width: 1320,
     height: 860,
@@ -139,6 +140,8 @@ function createWindow(): void {
   win.webContents.on('preload-error', (_event, preloadPath, error) => {
     console.error('[scrapeman] preload error:', preloadPath, error);
   });
+
+  return win;
 }
 
 function installContentSecurityPolicy(): void {
@@ -763,7 +766,8 @@ app.whenReady().then(() => {
       workspaceManager.setActiveEnvironment(workspacePath, name),
   );
 
-  createWindow();
+  const mainWindow = createWindow();
+  initAutoUpdater(mainWindow);
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow();

--- a/apps/desktop/src/main/updater.ts
+++ b/apps/desktop/src/main/updater.ts
@@ -1,0 +1,109 @@
+import { app, BrowserWindow, ipcMain, shell } from 'electron';
+import type { UpdateInfo } from '@scrapeman/shared-types';
+
+const RELEASES_URL =
+  'https://api.github.com/repos/scrape-do/scrapeman/releases/latest';
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4 hours
+const RATE_LIMIT_BACKOFF_MS = 60 * 60 * 1000; // 1 hour
+
+// Versions the user dismissed this session — don't re-emit for these.
+const dismissedVersions = new Set<string>();
+
+let checkTimer: ReturnType<typeof setInterval> | null = null;
+let rateLimitedUntil = 0;
+
+/**
+ * Compare two semver strings (e.g. "0.3.0" > "0.2.1").
+ * Returns true if `remote` is newer than `local`.
+ */
+function isNewerVersion(remote: string, local: string): boolean {
+  const r = remote.split('.').map(Number);
+  const l = local.split('.').map(Number);
+  const len = Math.max(r.length, l.length);
+  for (let i = 0; i < len; i++) {
+    const rv = r[i] ?? 0;
+    const lv = l[i] ?? 0;
+    if (rv > lv) return true;
+    if (rv < lv) return false;
+  }
+  return false;
+}
+
+async function checkForUpdate(mainWindow: BrowserWindow): Promise<void> {
+  if (Date.now() < rateLimitedUntil) return;
+
+  try {
+    const res = await fetch(RELEASES_URL, {
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+
+    // Handle rate limiting
+    if (
+      res.status === 403 &&
+      res.headers.get('x-ratelimit-remaining') === '0'
+    ) {
+      rateLimitedUntil = Date.now() + RATE_LIMIT_BACKOFF_MS;
+      return;
+    }
+
+    if (!res.ok) return;
+
+    const data = (await res.json()) as {
+      tag_name?: string;
+      html_url?: string;
+      published_at?: string;
+      body?: string;
+    };
+
+    const tagName = data.tag_name;
+    if (!tagName) return;
+
+    const version = tagName.replace(/^v/, '');
+    const currentVersion = app.getVersion();
+
+    if (!isNewerVersion(version, currentVersion)) return;
+    if (dismissedVersions.has(version)) return;
+
+    const info: UpdateInfo = {
+      version,
+      tagName,
+      releaseUrl: data.html_url ?? '',
+      publishedAt: data.published_at ?? '',
+      ...(data.body ? { notes: data.body } : {}),
+    };
+
+    if (!mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('update:available', info);
+    }
+  } catch {
+    // Network error, parse error — silently ignore, retry next interval.
+  }
+}
+
+export function initAutoUpdater(mainWindow: BrowserWindow): void {
+  // Listen for dismiss events from the renderer.
+  ipcMain.on('update:dismiss', (_e, version: string) => {
+    dismissedVersions.add(version);
+  });
+
+  // Listen for open-release-page events from the renderer.
+  ipcMain.on('update:open-release', (_e, url: string) => {
+    void shell.openExternal(url);
+  });
+
+  // Initial check (slight delay to not block startup).
+  void checkForUpdate(mainWindow);
+
+  // Periodic check every 4 hours.
+  checkTimer = setInterval(() => {
+    void checkForUpdate(mainWindow);
+  }, CHECK_INTERVAL_MS);
+
+  // Clean up on quit.
+  app.on('before-quit', () => {
+    if (checkTimer !== null) {
+      clearInterval(checkTimer);
+      checkTimer = null;
+    }
+  });
+}

--- a/apps/desktop/src/preload/index.ts
+++ b/apps/desktop/src/preload/index.ts
@@ -16,6 +16,7 @@ import type {
   RecentWorkspace,
   ScrapemanBridge,
   ScrapemanRequest,
+  UpdateInfo,
   WorkspaceEvent,
   WorkspaceTree,
 } from '@scrapeman/shared-types';
@@ -222,6 +223,19 @@ const api: ScrapemanBridge = {
     ipcRenderer.invoke('git:localHide', workspacePath, relPath) as Promise<void>,
   gitLocalUnhide: (workspacePath: string, relPath: string) =>
     ipcRenderer.invoke('git:localUnhide', workspacePath, relPath) as Promise<void>,
+
+  onUpdateAvailable: (handler: (info: UpdateInfo) => void) => {
+    const listener = (_event: unknown, payload: UpdateInfo): void =>
+      handler(payload);
+    ipcRenderer.on('update:available', listener);
+    return () => ipcRenderer.off('update:available', listener);
+  },
+  dismissUpdate: (version: string) => {
+    ipcRenderer.send('update:dismiss', version);
+  },
+  openReleasePage: (url: string) => {
+    ipcRenderer.send('update:open-release', url);
+  },
 };
 
 contextBridge.exposeInMainWorld('scrapeman', api);

--- a/apps/desktop/src/renderer/src/App.tsx
+++ b/apps/desktop/src/renderer/src/App.tsx
@@ -15,6 +15,7 @@ import { bridge } from './bridge.js';
 import { usePlatform } from './hooks/usePlatform.js';
 import { useShortcuts, type Shortcut } from './hooks/useShortcuts.js';
 import { useTheme } from './hooks/useTheme.js';
+import { UpdateBanner } from './components/UpdateBanner.js';
 
 export function App(): JSX.Element {
   const workspace = useAppStore((s) => s.workspace);
@@ -29,6 +30,7 @@ export function App(): JSX.Element {
   const activateTabByIndex = useAppStore((s) => s.activateTabByIndex);
   const reopenClosedTab = useAppStore((s) => s.reopenClosedTab);
   const activeTabId = useAppStore((s) => s.activeTabId);
+  const setUpdateInfo = useAppStore((s) => s.setUpdateInfo);
   const saveOrPrompt = useAppStore((s) => s.saveOrPrompt);
   const focusUrl = useAppStore((s) => s.focusUrl);
   const toggleHiddenRequest = useAppStore((s) => s.toggleHiddenRequest);
@@ -56,6 +58,10 @@ export function App(): JSX.Element {
     });
     return unsubscribe;
   }, [workspace, refreshTree, loadEnvironments]);
+
+  useEffect(() => {
+    return bridge.onUpdateAvailable((info) => setUpdateInfo(info));
+  }, [setUpdateInfo]);
 
   const [paletteOpen, setPaletteOpen] = useState(false);
 
@@ -256,6 +262,7 @@ export function App(): JSX.Element {
           }
           second={
             <div className="flex h-full flex-col overflow-hidden">
+              <UpdateBanner />
               <TabBar />
               <div className="flex-1 overflow-hidden">
                 <SplitPane

--- a/apps/desktop/src/renderer/src/components/UpdateBanner.tsx
+++ b/apps/desktop/src/renderer/src/components/UpdateBanner.tsx
@@ -1,0 +1,29 @@
+import { useAppStore } from '../store.js';
+import { bridge } from '../bridge.js';
+
+export function UpdateBanner(): JSX.Element | null {
+  const updateInfo = useAppStore((s) => s.updateInfo);
+  const dismissedVersions = useAppStore((s) => s.dismissedVersions);
+  const dismissUpdate = useAppStore((s) => s.dismissUpdate);
+
+  if (!updateInfo || dismissedVersions.includes(updateInfo.version)) return null;
+
+  return (
+    <div className="flex h-8 items-center justify-center gap-3 bg-accent/10 px-4 text-xs text-accent">
+      <span>Scrapeman v{updateInfo.version} is available</span>
+      <button
+        onClick={() => bridge.openReleasePage(updateInfo.releaseUrl)}
+        className="rounded bg-accent px-2 py-0.5 text-xs font-medium text-white hover:bg-accent/90"
+      >
+        Download
+      </button>
+      <button
+        onClick={() => dismissUpdate(updateInfo.version)}
+        className="ml-1 text-accent/60 hover:text-accent"
+        title="Dismiss"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/store.ts
+++ b/apps/desktop/src/renderer/src/store.ts
@@ -16,6 +16,7 @@ import type {
   ScrapeDoConfig,
   ScrapemanRequest,
   SerializedExecutorError,
+  UpdateInfo,
   WorkspaceInfo,
 } from '@scrapeman/shared-types';
 import { bridge } from './bridge.js';
@@ -191,6 +192,12 @@ interface AppState {
   renameNode: (relPath: string, newName: string) => Promise<void>;
   deleteNode: (relPath: string) => Promise<void>;
   moveNode: (relPath: string, newParentRelPath: string) => Promise<string | null>;
+
+  // Auto-update
+  updateInfo: UpdateInfo | null;
+  dismissedVersions: string[];
+  setUpdateInfo: (info: UpdateInfo) => void;
+  dismissUpdate: (version: string) => void;
 
   // Git
   gitStatus: GitStatus | null;
@@ -505,6 +512,22 @@ export const useAppStore = create<AppState>((set, get) => {
     history: [],
     tabs: [],
     activeTabId: null,
+    updateInfo: null,
+    dismissedVersions: [],
+    setUpdateInfo: (info) => {
+      const { dismissedVersions } = get();
+      if (dismissedVersions.includes(info.version)) return;
+      set({ updateInfo: info });
+    },
+    dismissUpdate: (version) => {
+      const { dismissedVersions } = get();
+      bridge.dismissUpdate(version);
+      set({
+        updateInfo: null,
+        dismissedVersions: [...dismissedVersions, version],
+      });
+    },
+
     gitStatus: null,
     gitLoaded: false,
     gitError: null,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -387,6 +387,14 @@ export interface CodegenInput {
   workspacePath?: string;
 }
 
+export interface UpdateInfo {
+  version: string;
+  tagName: string;
+  releaseUrl: string;
+  publishedAt: string;
+  notes?: string;
+}
+
 // IPC bridge contract — source of truth for preload + main + renderer.
 export interface ScrapemanBridge {
   ping: () => Promise<'pong'>;
@@ -509,4 +517,9 @@ export interface ScrapemanBridge {
   gitLocalHiddenList: (workspacePath: string) => Promise<string[]>;
   gitLocalHide: (workspacePath: string, relPath: string) => Promise<void>;
   gitLocalUnhide: (workspacePath: string, relPath: string) => Promise<void>;
+
+  // Auto-update
+  onUpdateAvailable: (handler: (info: UpdateInfo) => void) => () => void;
+  dismissUpdate: (version: string) => void;
+  openReleasePage: (url: string) => void;
 }


### PR DESCRIPTION
Kapatır #35 (Phase 1). Main process 4 saatte bir GitHub Releases API'sine sorgu atıp mevcut versiyonla karşılaştırıyor, yeni sürüm varsa renderer'da dismissable banner gösteriyor. Download butonu browser'da release sayfasını açıyor. electron-updater yok, binary download yok — sadece versiyon check + banner + shell.openExternal.

Yeni dosyalar: main/updater.ts, components/UpdateBanner.tsx
Değişen: shared-types (UpdateInfo + 3 bridge method), preload, main/index.ts, store.ts, App.tsx